### PR TITLE
Fix: Declare temporary variable before checking for empty

### DIFF
--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -449,7 +449,8 @@ class MdsColliveryService
             $id = $this->validated_data['service'];
             $services = $this->collivery->getServices();
 
-            if (!empty($this->settings->getValue("wording_$id"))) {
+	    $wordingId = $this->settings->getValue("wording_$id");
+            if (!empty($wordingId)) {
                 $reason = preg_replace('|' . preg_quote($services[$id]) . '|', $this->settings->getValue("wording_$id"), $this->validated_data['time_changed_reason']);
             } else {
                 $reason = $this->validated_data['time_changed_reason'];


### PR DESCRIPTION
Fixes Can't use method return value for PHP 5.4 and older