### PR TITLE
Bugfix/ep 9/errors with accepting collivery

### DIFF
--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -442,7 +442,11 @@ class MdsColliveryService
      */
     public function addCollivery(array $array)
     {
-        $this->validated_data = $this->validateCollivery($array);
+        $this->validated_data = $validatedData = $this->validateCollivery($array);
+
+	    if (is_null($validatedData)) {
+		    return false;
+	    }
 
         if (isset($this->validated_data['time_changed']) && $this->validated_data['time_changed'] == 1) {
             $id = $this->validated_data['service'];

--- a/MdsSupportingClasses/MdsLogger.php
+++ b/MdsSupportingClasses/MdsLogger.php
@@ -199,6 +199,7 @@ class MdsLogger
         if ($dir != '' && !is_dir($dir)) {
             $this->create_dir($dir_array);
             mkdir($dir);
+            chmod($dir, 755);
         }
     }
 

--- a/collivery.php
+++ b/collivery.php
@@ -1,18 +1,18 @@
 <?php
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.1.23');
+define('MDS_VERSION', '3.1.24');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.1.23
+ * Version: 3.1.24
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
- * WC requires at least: 3.3
- * WC tested up to: 3.5.7
+ * WC requires at least: 3.5
+ * WC tested up to: 3.6.2
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -389,7 +389,7 @@ function accept_admin_callback()
                 ));
 
                 // Check for any problems
-                if (!$collection_address) {
+                if ($collivery->hasErrors()) {
                     wp_send_json(array(
                         'redirect' => false,
                         'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
@@ -421,7 +421,7 @@ function accept_admin_callback()
                 ));
 
                 // Check for any problems
-                if (!$delivery_address) {
+                if ($collivery->hasErrors()) {
                     wp_send_json(array(
                         'redirect' => false,
                         'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',


### PR DESCRIPTION
* 8800908 [change] Update collivery and Woocommerce version numbers 
  - This is a bugfix, increment the "patch" version to 24 We have tested on latest WooCommerce, so update that.
* 7da90ee [bugfix] Do not process the "validated" data if it's null
  - When we exit early in `MdsColliveryService::addCollivery()`, the errors on the class will be processed 
  - When we don't exit, the `$validated_data` member will be processed as if it were an array and throw an exception.
* fb421a6 [bugfix] Check the `Collivery` instance for errors instead of `$delivery_address` as falsey
  - The initial way was adding another layer of validation instead of relying on the validation that's already done in the service layer
* 88a4274 [unrelated] Ensure we have write access to log directory. 
  - We have received reports of clients receiving a 403 when attempting to pull down log files