### PR TITLE
Bugfix/wp5.2/compatibility

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -1,18 +1,18 @@
 <?php
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.1.27.2');
+define('MDS_VERSION', '3.1.28');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.1.27.2
+ * Version: 3.1.28
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5
- * WC tested up to: 3.6.2
+ * WC tested up to: 3.7.0
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');

--- a/mds_checkout_fields.php
+++ b/mds_checkout_fields.php
@@ -92,15 +92,15 @@ if (!function_exists('generate_towns')) {
                 'WC' => 'CAP',
             );
             $province = isset($provinceMap[$_POST['parentValue']]) ? $provinceMap[$_POST['parentValue']] : 'unknown';
-            echo View::make('_options', array(
+            wp_send_json(View::make('_options', array(
                 'fields' => $collivery->getTowns('ZAF', $province),
                 'placeholder' => 'Select town/city',
                 'selectedValue' => $selectedTown,
-            ));
+            )));
         } else {
-            echo View::make('_options', array(
+            wp_send_json(View::make('_options', array(
                 'placeholder' => 'First select province',
-            ));
+            )));
         }
     }
 
@@ -129,20 +129,20 @@ if (!function_exists('generate_suburbs')) {
             $fields = $collivery->getSuburbs($town_id);
 
             if (!empty($fields)) {
-                echo View::make('_options', array(
+                wp_send_json(View::make('_options', array(
                     'fields' => $fields,
                     'placeholder' => 'Select suburb',
                     'selectedValue' => $selectedSuburb,
-                ));
+                )));
             } else {
-                echo View::make('_options', array(
+                wp_send_json(View::make('_options', array(
                     'placeholder' => 'Error retrieving data from server. Please try again later...',
-                ));
+                )));
             }
         } else {
-            echo View::make('_options', array(
+            wp_send_json(View::make('_options', array(
                 'placeholder' => 'First Select Town...',
-            ));
+            )));
         }
     }
 


### PR DESCRIPTION
### [bugfix] Replace `echo` in ajax response with a `wp_send_json()`
- If we simply use `echo` the `wp_die()` at the end of `admin-ajax.php` is reached
- A `"0"` will then be appended to the response string we send
- The errand `"0"` means that the html will not be parsed by `select2`
- Bump version numbers