### PR TITLE
Improvement/various

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -192,5 +192,6 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
             return $address;
         }
 
-    add_filter('woocommerce_my_account_my_address_formatted_address', 'mds_show_my_account_address_suburb', 10, 3);
+	    add_filter('woocommerce_my_account_my_address_formatted_address', 'mds_show_my_account_address_suburb', 10, 3);
+    }
 }

--- a/collivery.php
+++ b/collivery.php
@@ -1,5 +1,7 @@
 <?php
 
+use MdsSupportingClasses\MdsColliveryService;
+
 define('_MDS_DIR_', __DIR__);
 define('MDS_VERSION', '3.1.28');
 include 'autoload.php';
@@ -16,6 +18,9 @@ include 'autoload.php';
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');
+	$mds = MdsColliveryService::getInstance();
+	$settings = $mds->returnPluginSettings();
+
 
     if (!function_exists('activate_mds')) {
         /**
@@ -79,8 +84,10 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
             wp_enqueue_script('mds_js');
         }
 
-        add_action('wp_enqueue_scripts', 'load_js');
-
+	    $mds = MdsColliveryService::getInstance();
+	    if ($mds->isEnabled()) {
+		    add_action( 'wp_enqueue_scripts', 'load_js' );
+	    }
         /*
          * Check for updates
          */
@@ -91,7 +98,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 
     if (!function_exists('add_mds_shipping_method')) {
         /**
-         * Register Chipping Plugin with WooCommerce.
+         * Register Shipping Plugin with WooCommerce.
          *
          * @param $methods
          *
@@ -145,7 +152,9 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
             }
         }
 
-        add_action('woocommerce_payment_complete', 'automated_add_collivery_payment_complete');
+            if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
+	            add_action( 'woocommerce_payment_complete', 'automated_add_collivery_payment_complete' );
+            }
     }
 
     if (!function_exists('automated_add_collivery_status_processing')) {
@@ -167,7 +176,9 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
             }
         }
 
-        add_action('woocommerce_order_status_processing', 'automated_add_collivery_status_processing');
+        if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
+	        add_action('woocommerce_order_status_processing', 'automated_add_collivery_status_processing');
+        }
     }
 
     if (!function_exists('mds_change_default_checkout_country')) {
@@ -181,7 +192,9 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
             return 'ZA';
         }
 
-        add_filter('default_checkout_billing_country', 'mds_change_default_checkout_country');
+	    if ($mds->isEnabled()) {
+		    add_filter( 'default_checkout_billing_country', 'mds_change_default_checkout_country' );
+	    }
     }
 
     if (!function_exists('mds_show_my_account_address_suburb')) {
@@ -192,7 +205,6 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 
             return $address;
         }
-    }
 
     add_filter('woocommerce_my_account_my_address_formatted_address', 'mds_show_my_account_address_suburb', 10, 3);
 }

--- a/collivery.php
+++ b/collivery.php
@@ -22,7 +22,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
 	$settings = $mds->returnPluginSettings();
 
 
-    if (!function_exists('activate_mds')) {
+	if (!function_exists('activate_mds')) {
         /**
          * When the plugin is installed we check if the mds collivery table exists and if not creates it.
          */
@@ -64,8 +64,6 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
      */
     function init_mds_collivery()
     {
-        global $wpdb;
-
         // Check if 'WC_Shipping_Method' class is loaded, else exit.
         if (!class_exists('WC_Shipping_Method')) {
             return;
@@ -163,7 +161,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          *
          * @param $order_id
          *
-         * @return string
+         * @return bool|null
          */
         function automated_add_collivery_status_processing($order_id)
         {

--- a/collivery.php
+++ b/collivery.php
@@ -141,13 +141,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          */
         function automated_add_collivery_payment_complete($order_id)
         {
-            /** @var \MdsSupportingClasses\MdsColliveryService $mds */
-            $mds = MdsColliveryService::getInstance();
-            $settings = $mds->returnPluginSettings();
-
-            if ($settings->getValue('enabled') == 'yes' && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
-                $mds->automatedAddCollivery($order_id);
-            }
+	        return MdsColliveryService::getInstance()->automatedAddCollivery($order_id);
         }
 
             if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
@@ -165,13 +159,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          */
         function automated_add_collivery_status_processing($order_id)
         {
-            /** @var \MdsSupportingClasses\MdsColliveryService $mds */
-            $mds = MdsColliveryService::getInstance();
-            $settings = $mds->returnPluginSettings();
-
-            if ($settings->getValue('enabled') == 'yes' && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
-                $mds->automatedAddCollivery($order_id, true);
-            }
+	        return MdsColliveryService::getInstance()->automatedAddCollivery($order_id, true);
         }
 
         if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {

--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.1.28');
+define('MDS_VERSION', '3.2.0');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.1.28
+ * Version: 3.2.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -576,5 +576,5 @@ function mds_register_collivery()
         }
     }
 
-    echo View::make('order', compact('order', 'total', 'shipping_method', 'collivery', 'parcels', 'defaults', 'addresses', 'instructions', 'custom_fields', 'include_product_titles', 'towns', 'location_types', 'suburbs', 'populatedSuburbs', 'services', 'riskCover'));
+    echo View::make('order', compact('order', 'total', 'shipping_method', 'collivery', 'parcels', 'defaults', 'addresses', 'instructions', 'include_product_titles', 'towns', 'location_types', 'suburbs', 'populatedSuburbs', 'services', 'riskCover'));
 }

--- a/mds_checkout_fields.php
+++ b/mds_checkout_fields.php
@@ -1,151 +1,148 @@
 <?php
 
-if (!function_exists('mds_custom_override_default_address_fields')) {
-    /**
-     * Override the Billing and Shipping fields.
-     *
-     * @param $address_fields
-     *
-     * @return array
-     */
-    function mds_custom_override_default_address_fields($address_fields)
-    {
-        $mdsCheckoutFields = new \MdsSupportingClasses\MdsCheckoutFields($address_fields);
+use MdsSupportingClasses\MdsColliveryService;
 
-        return $mdsCheckoutFields->getCheckoutFields();
-    }
+$mds = MdsColliveryService::getInstance();
 
-    add_filter('woocommerce_default_address_fields', 'mds_custom_override_default_address_fields');
-}
+if ($mds->isEnabled()) {
+	if ( ! function_exists( 'mds_custom_override_default_address_fields' ) ) {
+		/**
+		 * Override the Billing and Shipping fields.
+		 *
+		 * @param $address_fields
+		 *
+		 * @return array
+		 */
+		function mds_custom_override_default_address_fields( $address_fields ) {
+			$mdsCheckoutFields = new \MdsSupportingClasses\MdsCheckoutFields( $address_fields );
 
-if (!function_exists('mds_custom_override_checkout_fields')) {
-    /**
-     * Override the Billing and Shipping fields in Checkout.
-     *
-     * @param $address_fields
-     *
-     * @return array
-     */
-    function mds_custom_override_checkout_fields($address_fields)
-    {
-        $mdsCheckoutFields = new \MdsSupportingClasses\MdsCheckoutFields($address_fields);
+			return $mdsCheckoutFields->getCheckoutFields();
+		}
 
-        $address_fields['billing'] = $mdsCheckoutFields->getCheckoutFields('billing');
-        $address_fields['shipping'] = $mdsCheckoutFields->getCheckoutFields('shipping');
+		add_filter( 'woocommerce_default_address_fields', 'mds_custom_override_default_address_fields' );
+	}
 
-        return $address_fields;
-    }
+	if ( ! function_exists( 'mds_custom_override_checkout_fields' ) ) {
+		/**
+		 * Override the Billing and Shipping fields in Checkout.
+		 *
+		 * @param $address_fields
+		 *
+		 * @return array
+		 */
+		function mds_custom_override_checkout_fields( $address_fields ) {
+			$mdsCheckoutFields = new \MdsSupportingClasses\MdsCheckoutFields( $address_fields );
 
-    add_filter('woocommerce_checkout_fields', 'mds_custom_override_checkout_fields');
-}
+			$address_fields['billing']  = $mdsCheckoutFields->getCheckoutFields( 'billing' );
+			$address_fields['shipping'] = $mdsCheckoutFields->getCheckoutFields( 'shipping' );
 
-if (!function_exists('mds_custom_checkout_field_update_order_meta')) {
-    /**
-     * Save our location type field.
-     *
-     * @param $order_id
-     */
-    function mds_custom_checkout_field_update_order_meta($order_id)
-    {
-        $mds = \MdsSupportingClasses\MdsColliveryService::getInstance();
+			return $address_fields;
+		}
 
-        if ($mds->isEnabled()) {
-            foreach (array('shipping_', 'billing_') as $prefix) {
-                foreach (array('suburb', 'location_type') as $field) {
-                    if (!empty($_POST[$prefix.$field])) {
-                        update_post_meta($order_id, $prefix.$field, sanitize_text_field($_POST[$prefix.$field]));
-                    }
-                }
-            }
-        }
-    }
+		add_filter( 'woocommerce_checkout_fields', 'mds_custom_override_checkout_fields' );
+	}
 
-    add_action('woocommerce_checkout_update_order_meta', 'mds_custom_checkout_field_update_order_meta');
-}
+	if ( ! function_exists( 'mds_custom_checkout_field_update_order_meta' ) ) {
+		/**
+		 * Save our location type field.
+		 *
+		 * @param $order_id
+		 */
+		function mds_custom_checkout_field_update_order_meta( $order_id ) {
+			foreach ( [ 'shipping_', 'billing_' ] as $prefix ) {
+				foreach ( [ 'suburb', 'location_type' ] as $field ) {
+					if ( ! empty( $_POST[ $prefix . $field ] ) ) {
+						update_post_meta( $order_id, $prefix . $field, sanitize_text_field( $_POST[ $prefix . $field ] ) );
+					}
+				}
+			}
+		}
 
-if (!function_exists('generate_towns')) {
-    /**
-     * Get the towns on province Change.
-     *
-     * @return string
-     */
-    function generate_towns()
-    {
-        $mds = \MdsSupportingClasses\MdsColliveryService::getInstance();
+		add_action( 'woocommerce_checkout_update_order_meta', 'mds_custom_checkout_field_update_order_meta' );
+	}
 
-        $selectedTown = null;
-        if (get_current_user_id() > 0) {
-            $selectedTown = $mds->extractUserProfileField(get_current_user_id(), $_POST['db_prefix'].'city');
-        }
+	if ( ! function_exists( 'generate_towns' ) ) {
+		/**
+		 * Get the towns on province Change.
+		 *
+		 * @return string
+		 */
+		function generate_towns() {
+			$mds = MdsColliveryService::getInstance();
 
-        if (isset($_POST['parentValue']) && $_POST['parentValue'] != '') {
-            $collivery = $mds->returnColliveryClass();
-            $provinceMap = array(
-                'EC' => 'EC',
-                'FS' => 'OFS',
-                'GP' => 'GAU',
-                'KZN' => 'KZN',
-                'LP' => 'NP',
-                'MP' => 'MP',
-                'NC' => 'NC',
-                'NW' => 'NW',
-                'WC' => 'CAP',
-            );
-            $province = isset($provinceMap[$_POST['parentValue']]) ? $provinceMap[$_POST['parentValue']] : 'unknown';
-            wp_send_json(View::make('_options', array(
-                'fields' => $collivery->getTowns('ZAF', $province),
-                'placeholder' => 'Select town/city',
-                'selectedValue' => $selectedTown,
-            )));
-        } else {
-            wp_send_json(View::make('_options', array(
-                'placeholder' => 'First select province',
-            )));
-        }
-    }
+			$selectedTown = null;
+			if ( get_current_user_id() > 0 ) {
+				$selectedTown = $mds->extractUserProfileField( get_current_user_id(), $_POST['db_prefix'] . 'city' );
+			}
 
-    add_action('wp_ajax_mds_collivery_generate_towns', 'generate_towns');
-    add_action('wp_ajax_nopriv_mds_collivery_generate_towns', 'generate_towns');
-}
+			if ( isset( $_POST['parentValue'] ) && $_POST['parentValue'] != '' ) {
+				$collivery   = $mds->returnColliveryClass();
+				$provinceMap = [
+					'EC'  => 'EC',
+					'FS'  => 'OFS',
+					'GP'  => 'GAU',
+					'KZN' => 'KZN',
+					'LP'  => 'NP',
+					'MP'  => 'MP',
+					'NC'  => 'NC',
+					'NW'  => 'NW',
+					'WC'  => 'CAP',
+				];
+				$province    = isset( $provinceMap[ $_POST['parentValue'] ] ) ? $provinceMap[ $_POST['parentValue'] ] : 'unknown';
+				wp_send_json( View::make( '_options', [
+					'fields'        => $collivery->getTowns( 'ZAF', $province ),
+					'placeholder'   => 'Select town/city',
+					'selectedValue' => $selectedTown,
+				] ) );
+			} else {
+				wp_send_json( View::make( '_options', [
+					'placeholder' => 'First select province',
+				] ) );
+			}
+		}
 
-if (!function_exists('generate_suburbs')) {
-    /**
-     * Get the Suburbs on Town Change.
-     *
-     * @return string
-     */
-    function generate_suburbs()
-    {
-        $mds = \MdsSupportingClasses\MdsColliveryService::getInstance();
+		add_action( 'wp_ajax_mds_collivery_generate_towns', 'generate_towns' );
+		add_action( 'wp_ajax_nopriv_mds_collivery_generate_towns', 'generate_towns' );
+	}
 
-        $selectedSuburb = null;
-        if (get_current_user_id() > 0) {
-            $selectedSuburb = $mds->extractUserProfileField(get_current_user_id(), $_POST['db_prefix'].'suburb');
-        }
+	if ( ! function_exists( 'generate_suburbs' ) ) {
+		/**
+		 * Get the Suburbs on Town Change.
+		 *
+		 * @return string
+		 */
+		function generate_suburbs() {
+			$mds = MdsColliveryService::getInstance();
 
-        if ((isset($_POST['parentValue'])) && ($_POST['parentValue'] != '')) {
-            $collivery = $mds->returnColliveryClass();
-            $town_id = array_search($_POST['parentValue'], $collivery->getTowns());
-            $fields = $collivery->getSuburbs($town_id);
+			$selectedSuburb = null;
+			if ( get_current_user_id() > 0 ) {
+				$selectedSuburb = $mds->extractUserProfileField( get_current_user_id(), $_POST['db_prefix'] . 'suburb' );
+			}
 
-            if (!empty($fields)) {
-                wp_send_json(View::make('_options', array(
-                    'fields' => $fields,
-                    'placeholder' => 'Select suburb',
-                    'selectedValue' => $selectedSuburb,
-                )));
-            } else {
-                wp_send_json(View::make('_options', array(
-                    'placeholder' => 'Error retrieving data from server. Please try again later...',
-                )));
-            }
-        } else {
-            wp_send_json(View::make('_options', array(
-                'placeholder' => 'First Select Town...',
-            )));
-        }
-    }
+			if ( ( isset( $_POST['parentValue'] ) ) && ( $_POST['parentValue'] != '' ) ) {
+				$collivery = $mds->returnColliveryClass();
+				$town_id   = array_search( $_POST['parentValue'], $collivery->getTowns() );
+				$fields    = $collivery->getSuburbs( $town_id );
 
-    add_action('wp_ajax_mds_collivery_generate_suburbs', 'generate_suburbs');
-    add_action('wp_ajax_nopriv_mds_collivery_generate_suburbs', 'generate_suburbs');
+				if ( ! empty( $fields ) ) {
+					wp_send_json( View::make( '_options', [
+						'fields'        => $fields,
+						'placeholder'   => 'Select suburb',
+						'selectedValue' => $selectedSuburb,
+					] ) );
+				} else {
+					wp_send_json( View::make( '_options', [
+						'placeholder' => 'Error retrieving data from server. Please try again later...',
+					] ) );
+				}
+			} else {
+				wp_send_json( View::make( '_options', [
+					'placeholder' => 'First Select Town...',
+				] ) );
+			}
+		}
+
+		add_action( 'wp_ajax_mds_collivery_generate_suburbs', 'generate_suburbs' );
+		add_action( 'wp_ajax_nopriv_mds_collivery_generate_suburbs', 'generate_suburbs' );
+	}
 }


### PR DESCRIPTION
* 8dad01f [change] Clean up of code, no effect on functionality
* de482a8 [change] Bump plugin version number 
  - I figure it's a big enough refactor to use a `minor` version bump for this
* ea62d90 [bugfix] Implement filter for `..._formatted_address` inside the `if(!function_exists())`
  - It appears to be the standard. 
  - I presume to prevent multiple bindings
* d17092d [change] Implement the changes made to bind filter instead of functions, simplify access to `automatedAddCollivery()`
* eb0e065 [change] Minor clean up of code, no effect on functionality
* b838b83 [change] Ensure aspects of the plugin don't get loaded of the plugin is not `enabled`
  - Wrap all of `mds_checkout_fields` in a check for the plugin being active 
  - Wrap the `filter` bindings instead of the function contents  
    * for functions that already implemented checks for `enabled`