### PR TITLE
Bugfix/select2/element width

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.2.0');
+define('MDS_VERSION', '3.2.1');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/collivery.php
+++ b/collivery.php
@@ -78,7 +78,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          */
         function load_js()
         {
-            wp_register_script('mds_js', plugins_url('script.js', __FILE__), array('jquery'));
+            wp_register_script('mds_js', plugins_url('script.js', __FILE__), array('jquery'), MDS_VERSION);
             wp_enqueue_script('mds_js');
         }
 

--- a/script.js
+++ b/script.js
@@ -39,6 +39,11 @@ jQuery(document).ready(function () {
 
     function updateSelect(fromField, field, prefix, db_prefix) {
         var fromEl = jQuery('#' + fromField), el = jQuery('#' + field);
+
+        // The width of the `el` is collapsed if a parent is overlapping it.
+        // See https://github.com/select2/select2/pull/5502
+        fromEl.data('select2').close();
+
         if (fromEl.val() !== '') {
             return ajax = jQuery.ajax({
                 type: 'POST',
@@ -71,7 +76,10 @@ jQuery(document).ready(function () {
         el.select2('destroy');
         el.html(html);
         try {
-            el.select2();
+            // use `width:'resolve'` so that the width of `el` matches the wrapper element
+            el.select2({
+              width: 'resolve',
+            });
         } catch(err) {
           console.log(err)
         }

--- a/script.js
+++ b/script.js
@@ -76,9 +76,9 @@ jQuery(document).ready(function () {
         el.select2('destroy');
         el.html(html);
         try {
-            // use `width:'resolve'` so that the width of `el` matches the wrapper element
+            // use `width:'100%'` so that the width of `el` matches the wrapper element
             el.select2({
-              width: 'resolve',
+              width: '100%',
             });
         } catch(err) {
           console.log(err)


### PR DESCRIPTION
* [bugfix] Fallback to 'width: 100%' as there were still rendering issues 
    - This is not ideal 
    - but the only way we could solve this without refactoring large parts of the plugin 
    - The alternative would be to send json not html and use `select2` native methods of dealing with `<option>`s
* [change] Bump version number. - Minor release for a single bugfix
* [change] Pass through a version number to `wp_register_script()` 
    - Is used to bust cache 
    - Use the MDS plugin version number
* [bugfix] Ensure the `select2` element does not render collapsed 
    - The width of the `el` is collapsed if a parent is overlapping it.
        * See https://github.com/select2/select2/pull/5502 
    - Use `width:'resolve'` so that the width of `el` matches the wrapper element