### PR TITLE
Improvement/javascript/prevent requerying

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.2.2');
+define('MDS_VERSION', '3.2.3');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.2.2
+ * Version: 3.2.3
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+var colliveryFieldsValues = {};
+
 jQuery(document).ready(function () {
     var select2fields = {
         city: 'Select your city/town',
@@ -23,7 +25,7 @@ jQuery(document).ready(function () {
         {fromField: 'shipping_city', field: 'shipping_suburb', prefix: 'suburbs', db_prefix: 'shipping'}
     ];
 
-    jQuery.each(ajaxUpdates, function (index, row) {
+  jQuery.each(ajaxUpdates, function (index, row) {
         var parentEl = jQuery('#' + row.fromField);
         parentEl.on('keydown', function (e) {
             var keyCode = e.keyCode || e.which;
@@ -35,10 +37,13 @@ jQuery(document).ready(function () {
         parentEl.on('change', function () {
             updateSelect(row.fromField, row.field, row.prefix, row.db_prefix);
         });
+
+        cacheValue(row.fromField, parentEl.val());
     });
 
     function updateSelect(fromField, field, prefix, db_prefix) {
-        var fromEl = jQuery('#' + fromField), el = jQuery('#' + field),
+        var fromEl = jQuery('#' + fromField),
+            el = jQuery('#' + field),
             fromSelect2 = fromEl.data('select2');
 
         // The width of the `el` is collapsed if a parent is overlapping it.
@@ -47,7 +52,10 @@ jQuery(document).ready(function () {
           fromSelect2.close();
         }
 
-        if (fromEl.val() !== '') {
+        // Check that the value is not empty and has changed from the previous value
+        // Only if that is true is there any point in querying for new results
+        if (fromEl.val() !== '' && fromEl.val() != colliveryFieldsValues[fromField]) {
+            cacheValue(fromField, fromEl.val());
             return ajax = jQuery.ajax({
                 type: 'POST',
                 async: false,
@@ -87,4 +95,8 @@ jQuery(document).ready(function () {
           console.log(err)
         }
     }
+
+  function cacheValue (key, val) {
+    colliveryFieldsValues[key] = val;
+  }
 });


### PR DESCRIPTION
* [change] Bump version number
* [improvement] Prevent re-querying API if not needed 
  - Implement an in-memory cache of current values
  - Validate against that before we re-query for towns/suburbs
  - This is as a result of some themes/plugins causing firing a manual `change` event on the fields