### PR TITLE
[bugfix] Prevent local cache from giving a false positive

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.2.3');
+define('MDS_VERSION', '3.2.4');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.2.3
+ * Version: 3.2.4
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/script.js
+++ b/script.js
@@ -46,6 +46,12 @@ jQuery(document).ready(function () {
             el = jQuery('#' + field),
             fromSelect2 = fromEl.data('select2');
 
+        // Ensure we clear the town from cache in case we are changing province
+        // Else if we come back to this province and this town - the suburbs won't update
+        if (fromField.indexOf('state') != -1) {
+          cacheValue(field, '');
+        }
+
         // The width of the `el` is collapsed if a parent is overlapping it.
         // See https://github.com/select2/select2/pull/5502
         if (fromSelect2) { // May be null if element is hidden


### PR DESCRIPTION
- If you are bouncing back and forth on provinces, the local cache would give a false positive
- In that case the suburbs would not appear
- To replicate consider the following:
```
Change from Western Cape (Cape Town) to Limpopo (don’t select a town)
Change back to Western Cape and re-select Cape Town
```