### PR TITLE
[improvement] Clear the suburb select on changing provinces

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.2.4');
+define('MDS_VERSION', '3.2.5');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.2.4
+ * Version: 3.2.5
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/script.js
+++ b/script.js
@@ -52,7 +52,7 @@ jQuery(document).ready(function () {
           cacheValue(field, '');
 
           // Clear the previously selected suburbs if the province changes
-          resetSelect($(db_prefix + '_suburb'), '<option selected="selected" value="">First Select Town...</option>');
+          resetSelect(jQuery(db_prefix + '_suburb'), '<option selected="selected" value="">First Select Town...</option>');
         }
 
         // The width of the `el` is collapsed if a parent is overlapping it.

--- a/script.js
+++ b/script.js
@@ -50,6 +50,9 @@ jQuery(document).ready(function () {
         // Else if we come back to this province and this town - the suburbs won't update
         if (fromField.indexOf('state') != -1) {
           cacheValue(field, '');
+
+          // Clear the previously selected suburbs if the province changes
+          resetSelect($(db_prefix + '_suburb'), '<option selected="selected" value="">First Select Town...</option>');
         }
 
         // The width of the `el` is collapsed if a parent is overlapping it.


### PR DESCRIPTION
- If you had a suburb selected previously and you then change provinces
  * The town was deselected, but suburb remained
- It had no effect on usability
  * You needed to select a new town anyhow,
  * Which would fetch new suburbs