### PR TITLE
Bugfix/checkout/preload suburbs

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -44,7 +44,7 @@ class Collivery
         );
 
         foreach ($config as $key => $value) {
-            $this->config->$key = $value;
+            $this->config->$key = trim($value);
         }
 
         if ($this->config->demo) {

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -44,7 +44,7 @@ class Collivery
         );
 
         foreach ($config as $key => $value) {
-            $this->config->$key = trim($value);
+            $this->config->$key = $key === 'user_password' ? $value : trim($value);
         }
 
         if ($this->config->demo) {

--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -46,6 +46,15 @@ class MdsCheckoutFields
             $resources = MdsFields::getResources($service);
             $towns = array('' => 'Select Town') + array_combine($resources['towns'], $resources['towns']);
             $location_types = array('' => 'Select Premises Type') + array_combine($resources['location_types'], $resources['location_types']);
+	        $customer = WC()->customer;
+	        $cityPrefix = $prefix ? $prefix : 'billing_';
+	        $townName = $customer->{"get_{$cityPrefix}city"}();
+	        $suburbs = array(0 => 'First select town/city');
+
+	        if ($townName) {
+		        $townId = array_search($townName, $resources['towns']);
+		        $suburbs = array_merge($suburbs, $service->returnColliveryClass()->getSuburbs($townId));
+	        }
 
             return array(
                 $prefix.'country' => array(
@@ -82,7 +91,7 @@ class MdsCheckoutFields
                     'required' => true,
                     'placeholder' => 'Please select',
                     'class' => array('form-row-wide', 'address-field'),
-                    'options' => array('First select town/city'),
+                    'options' => $suburbs,
                 ),
                 $prefix.'location_type' => array(
                     'priority' => 5,

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -17,6 +17,7 @@ class MdsFields
                     'If you have any errors with the MDS plugin, you can download log files and email them to integration@collivery.co.za for support, clearing cache can be useful if you have empty list of towns etc'
                 ),
                 'placeholder' => admin_url().'admin.php?page=mds_download_log_files',
+                'default' => null,
             ),
             'enabled' => array(
                 'title' => __('Enabled?'),
@@ -133,6 +134,7 @@ class MdsFields
                 'title' => __('Exclude these roles from free delivery'),
                 'type' => 'text',
                 'description' => __('Comma separated list of roles that must be excluded from free shipping'),
+                'default' => null,
             ),
             'free_local_only' => array(
                 'title' => __('Free Delivery Local Only'),

--- a/collivery.php
+++ b/collivery.php
@@ -3,18 +3,18 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.2.4');
+define('MDS_VERSION', '3.3.0');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.2.4
+ * Version: 3.3.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.7.1
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');


### PR DESCRIPTION
* [change] Bump version number 
    - Minor release as it's not just a small bugfix
* [change] Preload the suburbs with the checkout page if the town is available 
    - Use `WC_Customer::get_billing_city()`/`WC_Customer::get_shipping_city()` to get the town
* [bugfix] Ensure that we don't run into a "Headers already sent" error 
    - When debug mode is active and `wp_list_pluck($form_fields, 'default')` is called 
    - An `Undefined index` error was triggered and started output