### PR TITLE
Bugfix/checkout/compatibility

### DIFF
--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -49,7 +49,7 @@ class MdsCheckoutFields
 	        $customer = WC()->customer;
 	        $cityPrefix = $prefix ? $prefix : 'billing_';
 	        $townName = $customer->{"get_{$cityPrefix}city"}();
-	        $suburbs = array(0 => 'First select town/city');
+	        $suburbs = array('' => 'First select town/city');
 
 	        if ($townName) {
 		        $townId = array_search($townName, $resources['towns']);

--- a/script.js
+++ b/script.js
@@ -52,7 +52,7 @@ jQuery(document).ready(function () {
           cacheValue(field, '');
 
           // Clear the previously selected suburbs if the province changes
-          resetSelect(jQuery(db_prefix + '_suburb'), '<option selected="selected" value="">First Select Town...</option>');
+          resetSelect(jQuery('#' + db_prefix + '_suburb'), '<option selected="selected" value="">First Select Town...</option>');
         }
 
         // The width of the `el` is collapsed if a parent is overlapping it.

--- a/script.js
+++ b/script.js
@@ -44,11 +44,12 @@ jQuery(document).ready(function () {
     function updateSelect(fromField, field, prefix, db_prefix) {
         var fromEl = jQuery('#' + fromField),
             el = jQuery('#' + field),
-            fromSelect2 = fromEl.data('select2');
+            fromSelect2 = fromEl.data('select2'),
+            isChange = fromEl.val() !== '' && fromEl.val() != colliveryFieldsValues[fromField];
 
         // Ensure we clear the town from cache in case we are changing province
         // Else if we come back to this province and this town - the suburbs won't update
-        if (fromField.indexOf('state') != -1) {
+        if (fromField.indexOf('state') != -1 && isChange) {
           cacheValue(field, '');
 
           // Clear the previously selected suburbs if the province changes
@@ -63,7 +64,7 @@ jQuery(document).ready(function () {
 
         // Check that the value is not empty and has changed from the previous value
         // Only if that is true is there any point in querying for new results
-        if (fromEl.val() !== '' && fromEl.val() != colliveryFieldsValues[fromField]) {
+        if (isChange) {
             cacheValue(fromField, fromEl.val());
             return ajax = jQuery.ajax({
                 type: 'POST',


### PR DESCRIPTION
* [bugfix] prepend the `#` to select the suburb fields by id
* [bugfix] Prevent clearing suburbs on page load 
    - It appears that some plugins trigger a `change` event on the `city` fields on page load 
    - That trigger would have cleared the suburb `<select>`
* [bugfix] Prevent false positive on validation of suburbs 
    - WooCommerce validates against `select.val() === ''` 
    - This ensures the default suburb value does not pass validation