### PR TITLE
Feature/ep 17/free shipping exclude virtual & downloadable

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -56,7 +56,7 @@ class Collivery
     /**
      * Setup the Soap Object.
      *
-     * @return SoapClient MDS Collivery Soap Client
+     * @return bool
      */
     protected function init()
     {
@@ -79,7 +79,7 @@ class Collivery
     /**
      * Checks if the Soap Client has been set, and returns it.
      *
-     * @return SoapClient Webserver Soap Client
+     * @return SoapClient
      *
      * @throws SoapConnectionException
      */
@@ -172,8 +172,8 @@ class Collivery
 
                     return $authenticate;
                 } else {
-                    if (isset($result['error_id'])) {
-                        $this->setError($result['error_id'], $result['error']);
+                    if (isset($authenticate['error_id'])) {
+                        $this->setError($authenticate['error_id'], $authenticate['error']);
                     } else {
                         $this->setError('result_unexpected', 'No result returned.');
                     }
@@ -258,6 +258,7 @@ class Collivery
      * @param string $province Filter towns by South African Provinces
      *
      * @return array List of towns and their ID's
+     * @throws SoapConnectionException
      */
     public function getTowns($country = 'ZAF', $province = null)
     {
@@ -307,6 +308,7 @@ class Collivery
      * @param string $name Start of town/suburb name
      *
      * @return array List of towns and their ID's
+     * @throws SoapConnectionException
      */
     public function searchTowns($name)
     {
@@ -347,6 +349,7 @@ class Collivery
      * @param int $town_id ID of the Town to return suburbs for
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getSuburbs($town_id)
     {
@@ -385,6 +388,7 @@ class Collivery
      * delivery.
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getLocationTypes()
     {
@@ -421,6 +425,7 @@ class Collivery
      * Returns the available Collivery services types.
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getServices()
     {
@@ -457,6 +462,7 @@ class Collivery
      * Returns the available Parcel Type ID and value array for use in adding a collivery.
      *
      * @return array Parcel  Types
+     * @throws SoapConnectionException
      */
     public function getParcelTypes()
     {
@@ -495,6 +501,7 @@ class Collivery
      * @param int $address_id the ID of the address you wish to retrieve
      *
      * @return array Address
+     * @throws SoapConnectionException
      */
     public function getAddress($address_id)
     {
@@ -533,6 +540,7 @@ class Collivery
      * @param array $filter Filter Addresses
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getAddresses(array $filter = array())
     {
@@ -571,6 +579,7 @@ class Collivery
      * @param int $address_id Address ID
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getContacts($address_id)
     {
@@ -609,6 +618,7 @@ class Collivery
      * @param int $collivery_id Collivery waybill number
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getPod($collivery_id)
     {
@@ -649,6 +659,7 @@ class Collivery
      * @param int $collivery_id Collivery waybill number
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getWaybill($collivery_id)
     {
@@ -679,6 +690,7 @@ class Collivery
      * @param int $collivery_id Collivery waybill number
      *
      * @return array
+     * @throws SoapConnectionException
      */
     public function getParcelImageList($collivery_id)
     {
@@ -723,6 +735,7 @@ class Collivery
      * @return array Array containing all the information
      *               about the image including the image
      *               itself in base64
+     * @throws SoapConnectionException
      */
     public function getParcelImage($parcel_id)
     {
@@ -766,6 +779,7 @@ class Collivery
      * @param int $collivery_id Collivery ID
      *
      * @return array Collivery Status Information
+     * @throws SoapConnectionException
      */
     public function getStatus($collivery_id)
     {
@@ -806,6 +820,7 @@ class Collivery
      * @param array $data Address and Contact Information
      *
      * @return array Address ID and Contact ID
+     * @throws SoapConnectionException
      */
     public function addAddress(array $data)
     {
@@ -873,6 +888,7 @@ class Collivery
      * @param array $data New Contact Data
      *
      * @return int New Contact ID
+     * @throws SoapConnectionException
      */
     public function addContact(array $data)
     {
@@ -918,13 +934,14 @@ class Collivery
         }
     }
 
-    /**
-     * Returns the price based on the data provided.
-     *
-     * @param array $data Your Collivery Details
-     *
-     * @return array Pricing for details supplied
-     */
+	/**
+	 * Returns the price based on the data provided.
+	 *
+	 * @param array $data Your Collivery Details
+	 *
+	 * @return array Pricing for details supplied
+	 * @throws SoapConnectionException
+	 */
     public function getPrice(array $data)
     {
         $towns = $this->getTowns();
@@ -976,21 +993,22 @@ class Collivery
         }
     }
 
-    /**
-     * Validate Collivery.
-     *
-     * Returns the validated data array of all details pertaining to a collivery.
-     * This process validates the information based on services, time frames and parcel information.
-     * Dates and times may be altered during this process based on the collection and delivery towns service parameters.
-     * Certain towns are only serviced on specific days and between certain times.
-     * This function automatically alters the values.
-     * The parcels volumetric calculations are also done at this time.
-     * It is important that the data is first validated before a collivery can be added.
-     *
-     * @param array $data Properties of the new Collivery
-     *
-     * @return array The validated data
-     */
+	/**
+	 * Validate Collivery.
+	 *
+	 * Returns the validated data array of all details pertaining to a collivery.
+	 * This process validates the information based on services, time frames and parcel information.
+	 * Dates and times may be altered during this process based on the collection and delivery towns service parameters.
+	 * Certain towns are only serviced on specific days and between certain times.
+	 * This function automatically alters the values.
+	 * The parcels volumetric calculations are also done at this time.
+	 * It is important that the data is first validated before a collivery can be added.
+	 *
+	 * @param array $data Properties of the new Collivery
+	 *
+	 * @return array The validated data
+	 * @throws SoapConnectionException
+	 */
     public function validate(array $data)
     {
         $contacts_from = $this->getContacts($data['collivery_from']);
@@ -1069,6 +1087,7 @@ class Collivery
      * @param array $data Properties of the new Collivery
      *
      * @return int New Collivery ID
+     * @throws SoapConnectionException
      */
     public function addCollivery(array $data)
     {
@@ -1147,6 +1166,7 @@ class Collivery
      * @param int $collivery_id ID of the Collivery you wish to accept
      *
      * @return bool Has the Collivery been accepted
+     * @throws SoapConnectionException
      */
     public function acceptCollivery($collivery_id)
     {

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -409,23 +409,27 @@ class MdsColliveryService
         }
     }
 
-	/**
-	 * @param array $array
-	 * @param float $cartSubTotal
-	 * @param float $markup
-	 * @param float $fixedPrice
-	 *
-	 * @return float
-	 *
-	 * @throws InvalidColliveryDataException
-	 */
-    public function getPrice(array $array, $cartSubTotal, $markup, $fixedPrice)
+    /**
+     * @param array $array
+     * @param float $adjustedTotal
+     * @param float $markup
+     * @param float $fixedPrice
+     *
+     * @return float
+     *
+     * @throws InvalidColliveryDataException
+     * @throws SoapConnectionException
+     */
+    public function getPrice(array $array, $adjustedTotal, $markup, $fixedPrice)
     {
         if (!$result = $this->collivery->getPrice($array)) {
             throw new InvalidColliveryDataException('Unable to get price from MDS', 'MdsColliveryService::getPrice', $this->loggerSettingsArray(), array('errors' => $this->collivery->getErrors(), 'data' => $array));
         }
 
-        if ($this->settings->getValue('method_free') === 'discount' && $cartSubTotal >= $this->settings->getValue('free_min_total')) {
+        $discountEnabled = $this->settings->getValue( 'method_free' ) === 'discount';
+        $overThreshold   = $adjustedTotal >= $this->settings->getValue( 'free_min_total' );
+
+        if ( $discountEnabled && $overThreshold ) {
             $discount = $this->settings->getValue('shipping_discount_percentage');
         } else {
             $discount = 0;

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -55,6 +55,18 @@ class MdsFields
                 'description' => __('Includes customer note which appended to the delivery instructions which max characters is 4096'),
                 'default' => 'no',
             ),
+            'round' => array(
+                'title' => 'MDS '.__('Round Price'),
+                'type' => 'checkbox',
+                'description' => __('Rounds price up.'),
+                'default' => 'yes',
+            ),
+            'include_vat' => array(
+                'title' => 'MDS '.__('Use Inclusive Amount'),
+                'type' => 'checkbox',
+                'description' => __('If Woocommerce is setup to add VAT onto the shipping cost then you should uncheck this box to use the exclusive amount, this way VAT will only be applied once. If your not adding VAT onto the shipping cost using Woocommerce then always use the inclusive amount. This option only affects the price displayed on your checkout page, MDS Collivery will always bill you the inclusive amount.'),
+                'default' => 'yes',
+            ),
             'risk_cover' => array(
                 'title' => 'MDS '.__('Risk Cover'),
                 'type' => 'checkbox',
@@ -99,7 +111,7 @@ class MdsFields
                 'title' => __('Percentage discount for shipping'),
                 'type' => 'number',
                 'description' => __(
-                    'The percentage discount that users get when their cart total exceeds <strong>"Free Delivery Min Total"</strong>'
+                    'The percentage discount that users get when their cart total exceeds <strong>"Free/Discount Delivery Min Total"</strong>'
                 ),
                 'default' => 10,
                 'custom_attributes' => array(
@@ -107,22 +119,6 @@ class MdsFields
                     'max' => 100,
                     'step' => 0.1,
                 ),
-            ),
-            'toggle_automatic_mds_processing' => array(
-                'title' => __('Automatic MDS Processing'),
-                'type' => 'checkbox',
-                'description' => __(
-                    'When enabled deliveries for an order will be automatically processed. Please refer to the manual for detailed information on implications on using this <a target="_blank" href="http://collivery.github.io/Collivery-WooCommerce/">Manual</a>'
-                ),
-                'default' => 'no',
-            ),
-            'auto_accept' => array(
-                'title' => __('Auto accept'),
-                'type' => 'checkbox',
-                'description' => __(
-                    'After automatic mds processing has sent the request through to MDS, should the request be auto accepted or will you manually accept the delivery on the MDS website'
-                ),
-                'default' => 'yes',
             ),
             'wording_free' => array(
                 'title' => __('Free Delivery Wording'),
@@ -133,7 +129,7 @@ class MdsFields
                 ),
             ),
             'free_min_total' => array(
-                'title' => __('Free Delivery Min Total'),
+                'title' => __('Free/Discount Delivery Min Total'),
                 'type' => 'number',
                 'description' => __('Min order total before free delivery is included, amount is including vat.'),
                 'default' => '1000.00',
@@ -156,6 +152,22 @@ class MdsFields
                 'custom_attributes' => array(
                     'data-type' => 'free-delivery-item',
                 ),
+            ),
+            'toggle_automatic_mds_processing' => array(
+                'title' => __('Automatic MDS Processing'),
+                'type' => 'checkbox',
+                'description' => __(
+                    'When enabled deliveries for an order will be automatically processed. Please refer to the manual for detailed information on implications on using this <a target="_blank" href="https://github.com/Collivery/Collivery-WooCommerce/">Manual</a>'
+                ),
+                'default' => 'no',
+            ),
+            'auto_accept' => array(
+                'title' => __('Auto accept'),
+                'type' => 'checkbox',
+                'description' => __(
+                    'After automatic mds processing has sent the request through to MDS, should the request be auto accepted or will you manually accept the delivery on the MDS website'
+                ),
+                'default' => 'yes',
             ),
         );
     }

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -81,17 +81,17 @@ class MdsFields
                     ),
                 'default' => 1000.00,
             ),
-            'round' => array(
-                'title' => 'MDS '.__('Round Price'),
+            'fee_exclude_virtual' => array(
+                'title' => __('Exclude "Virtual" From Calculations'),
                 'type' => 'checkbox',
-                'description' => __('Rounds price up.'),
-                'default' => 'yes',
+                'description' => __('Do not include products marked as "virtual" in the calculation for free/discounted deliveries or towards the "Risk cover minimum".'),
+                'default' => 'no',
             ),
-            'include_vat' => array(
-                'title' => 'MDS '.__('Use Inclusive Amount'),
+            'fee_exclude_downloadable' => array(
+                'title' => __('Exclude "Downloadable" From Calculations'),
                 'type' => 'checkbox',
-                'description' => __('If Woocommerce is setup to add VAT onto the shipping cost then you should uncheck this box to use the exclusive amount, this way VAT will only be applied once. If your not adding VAT onto the shipping cost using Woocommerce then always use the inclusive amount. This option only affects the price displayed on your checkout page, MDS Collivery will always bill you the inclusive amount.'),
-                'default' => 'yes',
+                'description' => __('Do not include products marked as "downloadable" in the calculation for free/discounted deliveries or towards the "Risk cover minimum".'),
+                'default' => 'no',
             ),
             'method_free' => array(
                 'title' => __('Free Delivery mode'),

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -22,7 +22,6 @@ class MdsFields
             'enabled' => array(
                 'title' => __('Enabled?'),
                 'type' => 'checkbox',
-                'label' => __('Enable this shipping method'),
                 'default' => 'yes',
             ),
             'mds_user' => array(
@@ -94,17 +93,14 @@ class MdsFields
                 'default' => 'no',
             ),
             'method_free' => array(
-                'title' => __('Free Delivery mode'),
-                'label' => __('Free Delivery: Enabled'),
+                'title' => __('Free/Discount Delivery mode'),
                 'type' => 'select',
+                'description' => __('Whether to offer free or discounted deliveries if the cart total exceeds the value of "Free/Discount Delivery Min Total".'),
                 'default' => 'no',
                 'options' => array(
                     'no' => __('No free deliveries'),
                     'yes' => __('Free delivery'),
-                    'discount' => _('Discount on deliveries'),
-                ),
-                'custom_attributes' => array(
-                    'title' => 'Choose shipping mode',
+                    'discount' => __('Discount on deliveries'),
                 ),
             ),
             'shipping_discount_percentage' => array(
@@ -131,7 +127,7 @@ class MdsFields
             'free_min_total' => array(
                 'title' => __('Free/Discount Delivery Min Total'),
                 'type' => 'number',
-                'description' => __('Min order total before free delivery is included, amount is including vat.'),
+                'description' => __('Minimum order total before free delivery is included, amount is including vat.'),
                 'default' => '1000.00',
                 'custom_attributes' => array(
                     'step' => .1,
@@ -186,7 +182,6 @@ class MdsFields
             foreach ($resources['services'] as $id => $title) {
                 $fields['method_'.$id] = array(
                     'title' => __($title),
-                    'label' => __($title.': Enabled'),
                     'type' => 'checkbox',
                     'default' => 'yes',
                 );

--- a/MdsSupportingClasses/ShippingPackageData.php
+++ b/MdsSupportingClasses/ShippingPackageData.php
@@ -81,16 +81,17 @@ class ShippingPackageData
             'country' => 'ZA',
         );
 
-        if (!isset($_POST['ship_to_different_address']) || $_POST['ship_to_different_address'] != true) {
-            $package['destination']['state'] = WC()->customer->get_billing_state();
-            $package['destination']['postcode'] = WC()->customer->get_billing_postcode();
-            $package['destination']['address'] = WC()->customer->get_billing_address_1();
-            $package['destination']['address_2'] = WC()->customer->get_billing_address_2();
+        $customer = WC ()->customer;
+        if ( !isset($_POST['ship_to_different_address']) || $_POST['ship_to_different_address'] != true) {
+            $package['destination']['state'] = $customer->get_billing_state();
+            $package['destination']['postcode'] = $customer->get_billing_postcode();
+            $package['destination']['address'] = $customer->get_billing_address_1();
+            $package['destination']['address_2'] = $customer->get_billing_address_2();
         } else {
-            $package['destination']['state'] = WC()->customer->get_shipping_state();
-            $package['destination']['postcode'] = WC()->customer->get_shipping_postcode();
-            $package['destination']['address'] = WC()->customer->get_shipping_address_1();
-            $package['destination']['address_2'] = WC()->customer->get_shipping_address_2();
+            $package['destination']['state'] = $customer->get_shipping_state();
+            $package['destination']['postcode'] = $customer->get_shipping_postcode();
+            $package['destination']['address'] = $customer->get_shipping_address_1();
+            $package['destination']['address_2'] = $customer->get_shipping_address_2();
         }
 
         if (!$this->service->validPackage($package)) {

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -139,10 +139,9 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                             if ($this->mdsSettings->getInstanceValue("method_$id") == 'yes') {
                                 // Now lets get the price for
                                 $riskCover = 0;
-                                $cartTotal = $package['cart']['total'];
                                 $adjustedTotal = $package['shipping_cart_total'];
                                 $riskCoverEnabled = $this->mdsSettings->getValue( 'risk_cover' ) == 'yes';
-                                $overThreshold = $cartTotal >= $this->mdsSettings->getValue( 'risk_cover_threshold', 1000 );
+                                $overThreshold = $adjustedTotal >= $this->mdsSettings->getValue( 'risk_cover_threshold', 1000 );
                                 if ( $riskCoverEnabled && $overThreshold ) {
                                     $riskCover = 1;
                                 }

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -140,7 +140,10 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                 // Now lets get the price for
                                 $riskCover = 0;
                                 $cartTotal = $package['cart']['total'];
-                                if ($this->mdsSettings->getValue('risk_cover') == 'yes' && ($cartTotal >= $this->mdsSettings->getValue('risk_cover_threshold', 1000))) {
+                                $adjustedTotal = $package['shipping_cart_total'];
+                                $riskCoverEnabled = $this->mdsSettings->getValue( 'risk_cover' ) == 'yes';
+                                $overThreshold = $cartTotal >= $this->mdsSettings->getValue( 'risk_cover_threshold', 1000 );
+                                if ( $riskCoverEnabled && $overThreshold ) {
                                     $riskCover = 1;
                                 }
 
@@ -157,7 +160,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     'service' => $id,
                                 );
 
-                                $price = $this->collivery_service->getPrice($data, WC()->cart->get_cart_contents_total(), $this->mdsSettings->getInstanceValue('markup_' . $id), $this->mdsSettings->getInstanceValue('fixed_price_' . $id));
+                                $price = $this->collivery_service->getPrice($data, $adjustedTotal, $this->mdsSettings->getInstanceValue( 'markup_' . $id), $this->mdsSettings->getInstanceValue( 'fixed_price_' . $id));
 
                                 if ($this->mdsSettings->getInstanceValue("wording_$id", $title) == $title && ($id == 1 || $id == 2)) {
                                     $title = $title.', additional 24 hours on outlying areas';

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -67,13 +67,14 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
     public function init()
     {
         $this->title = $this->method_title;
-        $this->enabled = get_option('enabled');
 
         // Load the form fields.
         $this->init_form_fields();
         $this->init_mds_collivery();
         $this->init_instance_form_fields();
         $this->mdsSettings = $this->collivery_service->initSettings($this->settings, $this->instance_settings);
+
+        $this->enabled = $this->mdsSettings->getValue('enabled', $this->enabled);
 
         add_action('woocommerce_update_options_shipping_'.$this->id, array($this, 'process_admin_options'));
     }

--- a/autoload.php
+++ b/autoload.php
@@ -17,7 +17,6 @@ class MdsColliveryAutoLoader
         'ParseDown' => '\MdsSupportingClasses\ParseDown',
         'UnitConverter' => '\MdsSupportingClasses\UnitConverter',
         'View' => '\MdsSupportingClasses\View',
-        'DiscountCalculator' => '\MdsSupportingClasses\DiscountCalculator',
         'ExceptionMiddleware' => '\MdsExceptions\ExceptionMiddleware',
         'InvalidAddressDataException' => '\MdsExceptions\InvalidAddressDataException',
         'InvalidCartPackageException' => '\MdsExceptions\InvalidCartPackageException',

--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.4.1');
+define('MDS_VERSION', '3.5.0');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.4.1
+ * Version: 3.5.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5


### PR DESCRIPTION
* EP-17 : [change] Clean up the `Collivery` class that wraps he `SoapClient` 
    - Add missing `@throws` tags 
    - Update some incorrect doc-blocks
    - Rename an undefined variable
* EP-17 : [change] Remove declaration of non-existent class
* EP-17 : [change] Refactor the admin page fields slightly
    - Modify the order to better logically group sections
    - Update references to "Free" to include "Discount" (for clarity's sake)
* EP-17 : [change] Add the `Exclude "Virtual"` and `Exclude "Downloable"` fields to admin section
    - This setting means that virtual or downloadable products do not count towards threshold totals   
        * ie. Free shipping, Discounted  shipping, Risk cover
* EP-17 : [unrelated-bugfix] Only get the `enabled` option once we have booted the settings
    - The `get_option()` call was giving inconsistent results,
    - Use our property bag of `MdsSettings` rather
* EP-17 : [change] Implement using the `fee_exclude_*` to calculate price and check for free shipping
    - Also simplify the `if() ... else()` in `ShippingPackageData::build()`
* EP-17 : [change] Optimise calls to `WC()->customer`
    - Keep it as a local variable to access instead of 4 calls to it
    - Micro-optimisation
* EP-17 : [change] Implement using the `fee_exclude_*` to calculate price from `WC_Order` data
    - Check for `risk_cover` based on that calculation
    - This is used in the back-end once the `WC_Cart` has been stored in the DB
* EP-17 : [change] Implement using the `fee_exclude_*` to calculate price and check for discount percentage
    - Relies on the `$adjustedTotal` amount passed in