### PR TITLE
Improvements/clean up

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -62,9 +62,10 @@ class Collivery
     {
         if (!$this->client) {
             try {
+                $wsdlUrl = getenv('COLLIVERY_URL') ?: 'https://www.collivery.co.za/wsdl/v2';
                 $this->client = new SoapClient(// Setup the soap client
-                    'http://www.collivery.co.za/wsdl/v2', // URL to WSDL File
-                    array('cache_wsdl' => WSDL_CACHE_NONE) // Don't cache the WSDL file
+                    $wsdlUrl, // URL to WSDL File
+                    ['cache_wsdl' => WSDL_CACHE_NONE] // Don't cache the WSDL file
                 );
             } catch (SoapFault $e) {
                 $this->catchSoapFault($e);

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -11,7 +11,7 @@ class Collivery
     protected $token;
     protected $client;
     protected $config;
-    protected $errors = array();
+    protected $errors = [];
     protected $check_cache = 2;
 
     protected $default_address_id;
@@ -24,7 +24,7 @@ class Collivery
      * @param array $config Configuration Array
      * @param Class $cache  Caching Class with functions has, get, put, forget
      */
-    public function __construct(array $config = array(), $cache = null)
+    public function __construct(array $config = [], $cache = null)
     {
         if (is_null($cache)) {
             $cache_dir = array_key_exists('cache_dir', $config) ? $config['cache_dir'] : null;
@@ -33,7 +33,7 @@ class Collivery
             $this->cache = $cache;
         }
 
-        $this->config = (object) array(
+        $this->config = (object) [
             'app_name' => 'Default App Name', // Application Name
             'app_version' => '0.0.1',            // Application Version
             'app_host' => '', // Framework/CMS name and version, eg 'Wordpress 3.8.1 WooCommerce 2.0.20' / 'Joomla! 2.5.17 VirtueMart 2.0.26d'
@@ -41,7 +41,7 @@ class Collivery
             'user_email' => 'api@collivery.co.za',
             'user_password' => 'api123',
             'demo' => false,
-        );
+        ];
 
         foreach ($config as $key => $value) {
             $this->config->$key = $key === 'user_password' ? $value : trim($value);
@@ -150,13 +150,13 @@ class Collivery
         if ($this->init()) {
             try {
                 $authenticate = $this->client->authenticate($user_email, $user_password, $token,
-                    array(
+                    [
                         'name' => $this->config->app_name.' mds/collivery/class',
                         'version' => $this->config->app_version,
                         'host' => $this->config->app_host,
                         'url' => $this->config->app_url,
                         'lang' => 'PHP '.phpversion(),
-                    ));
+                    ]);
 
                 if (is_array($authenticate) && isset($authenticate['token'])) {
                     if ($this->check_cache != 0) {
@@ -237,7 +237,7 @@ class Collivery
      */
     public function getProvinces()
     {
-        return array(
+        return [
             'CAP' => 'Western Cape',
             'EC' => 'Eastern Cape',
             'GAU' => 'Gauteng',
@@ -247,7 +247,7 @@ class Collivery
             'NP' => 'Limpopo',
             'NW' => 'North-West',
             'OFS' => 'Free State',
-        );
+        ];
     }
 
     /**
@@ -542,7 +542,7 @@ class Collivery
      * @return array
      * @throws SoapConnectionException
      */
-    public function getAddresses(array $filter = array())
+    public function getAddresses(array $filter = [])
     {
         if (($this->check_cache == 2) && empty($filter) && $this->cache->has('collivery.addresses.'.$this->client_id)) {
             return $this->cache->get('collivery.addresses.'.$this->client_id);
@@ -1237,7 +1237,7 @@ class Collivery
      */
     public function clearErrors()
     {
-        $this->errors = array();
+        $this->errors = [];
     }
 
     /**
@@ -1300,9 +1300,9 @@ class Collivery
      */
     public function getCurrentUsernameAndPassword()
     {
-        return array(
+        return [
             'email' => $this->config->user_email,
             'password' => $this->config->user_password,
-        );
+        ];
     }
 }

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -106,7 +106,7 @@ class Collivery
     /**
      * Authenticate and set the token.
      *
-     * @return string
+     * @return array
      */
     protected function authenticate()
     {
@@ -122,7 +122,7 @@ class Collivery
             $this->user_id = $authCache['user_id'];
             $this->token = $authCache['token'];
 
-            return true;
+            return $authCache;
         } else {
             return $this->makeAuthenticationRequest();
         }
@@ -133,7 +133,7 @@ class Collivery
      *
      * @param null|array $settings
      *
-     * @return array|bool
+     * @return array
      */
     private function makeAuthenticationRequest($settings = null)
     {
@@ -183,7 +183,7 @@ class Collivery
             }
         }
 
-        return false;
+        return [];
     }
 
     /**
@@ -294,7 +294,7 @@ class Collivery
                     $this->setError('result_unexpected', 'No result returned.');
                 }
 
-                return false;
+                return [];
             }
         }
     }
@@ -322,7 +322,7 @@ class Collivery
             } catch (SoapFault $e) {
                 $this->catchSoapFault($e);
 
-                return false;
+                return [];
             }
 
             if (isset($result)) {
@@ -338,7 +338,7 @@ class Collivery
                     $this->setError('result_unexpected', 'No result returned.');
                 }
 
-                return false;
+                return [];
             }
         }
     }
@@ -361,7 +361,7 @@ class Collivery
             } catch (SoapFault $e) {
                 $this->catchSoapFault($e);
 
-                return false;
+                return [];
             }
 
             if (isset($result['suburbs'])) {
@@ -377,7 +377,7 @@ class Collivery
                     $this->setError('result_unexpected', 'No result returned.');
                 }
 
-                return false;
+                return [];
             }
         }
     }

--- a/MdsSupportingClasses/GitHubPluginUpdater.php
+++ b/MdsSupportingClasses/GitHubPluginUpdater.php
@@ -26,9 +26,9 @@ class GitHubPluginUpdater
         $this->repo = $gitHubProjectName;
         $this->accessToken = $accessToken;
 
-        add_filter('pre_set_site_transient_update_plugins', array($this, 'setTransitent'));
-        add_filter('plugins_api', array($this, 'setPluginInfo'), 10, 3);
-        add_filter('upgrader_post_install', array($this, 'postInstall'), 10, 3);
+        add_filter('pre_set_site_transient_update_plugins', [$this, 'setTransitent']);
+        add_filter('plugins_api', [$this, 'setPluginInfo'], 10, 3);
+        add_filter('upgrader_post_install', [$this, 'postInstall'], 10, 3);
     }
 
     /**
@@ -56,7 +56,7 @@ class GitHubPluginUpdater
 
         // We need the access token for private repositories
         if (!empty($this->accessToken)) {
-            $url = add_query_arg(array('access_token' => $this->accessToken), $url);
+            $url = add_query_arg(['access_token' => $this->accessToken], $url);
         }
 
         // Get the results
@@ -98,7 +98,7 @@ class GitHubPluginUpdater
 
             // Include the access token for private GitHub repos
             if (!empty($this->accessToken)) {
-                $package = add_query_arg(array('access_token' => $this->accessToken), $package);
+                $package = add_query_arg(['access_token' => $this->accessToken], $package);
             }
 
             $obj = new \stdClass();
@@ -146,7 +146,7 @@ class GitHubPluginUpdater
         // Include the access token for private GitHub repos
         if (!empty($this->accessToken)) {
             $downloadLink = add_query_arg(
-                array('access_token' => $this->accessToken),
+                ['access_token' => $this->accessToken],
                 $downloadLink
             );
         }
@@ -156,12 +156,12 @@ class GitHubPluginUpdater
         require_once plugin_dir_path(__FILE__).'ParseDown.php';
 
         // Create tabs in the lightbox
-        $response->sections = array(
+        $response->sections = [
             'description' => $this->pluginData['Description'],
             'changelog' => class_exists('ParseDown')
                     ? ParseDown::instance()->parse($this->githubAPIResult->body)
                     : $this->githubAPIResult->body,
-        );
+        ];
 
         // Gets the required version of WP if available
         $matches = null;

--- a/MdsSupportingClasses/MdsCache.php
+++ b/MdsSupportingClasses/MdsCache.php
@@ -115,7 +115,7 @@ class MdsCache
      */
     public function put($name, $value, $time = 1440)
     {
-        $cache = array('value' => $value, 'valid' => time() + ($time * 60));
+        $cache = ['value' => $value, 'valid' => time() + ($time * 60)];
         if (file_put_contents($this->cache_dir.$name, json_encode($cache))) {
             $this->cache[$name] = $cache;
 
@@ -210,7 +210,7 @@ class MdsCache
      */
     public function forget($name)
     {
-        $cache = array('value' => '', 'valid' => 0);
+        $cache = ['value' => '', 'valid' => 0];
         if (file_put_contents($this->cache_dir.$name, json_encode($cache))) {
             $this->cache[$name] = $cache;
 
@@ -228,7 +228,7 @@ class MdsCache
     private function directory_map()
     {
         if ($fp = @opendir($this->cache_dir)) {
-            $file_data = array();
+            $file_data = [];
 
             while (false !== ($file = readdir($fp))) {
                 // Remove '.', '..', and hidden files

--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -9,7 +9,7 @@ class MdsCheckoutFields
     /**
      * @var array
      */
-    protected $defaultFields = array();
+    protected $defaultFields = [];
 
     /**
      * CheckoutFields constructor.
@@ -44,136 +44,136 @@ class MdsCheckoutFields
 
         try {
             $resources = MdsFields::getResources($service);
-            $towns = array('' => 'Select Town') + array_combine($resources['towns'], $resources['towns']);
-            $location_types = array('' => 'Select Premises Type') + array_combine($resources['location_types'], $resources['location_types']);
+            $towns = ['' => 'Select Town'] + array_combine($resources['towns'], $resources['towns']);
+            $location_types = ['' => 'Select Premises Type'] + array_combine($resources['location_types'], $resources['location_types']);
 	        $customer = WC()->customer;
 	        $cityPrefix = $prefix ? $prefix : 'billing_';
 	        $townName = $customer->{"get_{$cityPrefix}city"}();
-	        $suburbs = array('' => 'First select town/city');
+	        $suburbs = ['' => 'First select town/city'];
 
 	        if ($townName) {
 		        $townId = array_search($townName, $resources['towns']);
 		        $suburbs = $suburbs + $service->returnColliveryClass()->getSuburbs($townId);
 	        }
 
-            return array(
-                $prefix.'country' => array(
+            return [
+                $prefix.'country' => [
                     'priority' => 1,
                     'type' => 'country',
                     'label' => 'Country',
                     'required' => true,
                     'autocomplete' => 'country',
-                    'class' => array('form-row-wide', 'address-field', 'update_totals_on_change'),
-                ),
-                $prefix.'state' => array(
+                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
+                ],
+                $prefix.'state' => [
                     'priority' => 2,
                     'type' => 'state',
                     'label' => 'Province',
                     'required' => true,
-                    'class' => array('form-row-wide', 'address-field', 'update_totals_on_change'),
+                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
                     'placeholder' => 'Please select',
-                    'validate' => array('state'),
+                    'validate' => ['state'],
                     'autocomplete' => 'address-level1',
-                ),
-                $prefix.'city' => array(
+                ],
+                $prefix.'city' => [
                     'priority' => 3,
                     'type' => 'select',
                     'label' => 'Town / City',
                     'required' => true,
                     'placeholder' => 'Please select',
                     'options' => $towns,
-                    'class' => array('form-row-wide', 'address-field', 'update_totals_on_change'),
-                ),
-                $prefix.'suburb' => array(
+                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
+                ],
+                $prefix.'suburb' => [
                     'priority' => 4,
                     'type' => 'select',
                     'label' => 'Suburb',
                     'required' => true,
                     'placeholder' => 'Please select',
-                    'class' => array('form-row-wide', 'address-field'),
+                    'class' => ['form-row-wide', 'address-field'],
                     'options' => $suburbs,
-                ),
-                $prefix.'location_type' => array(
+                ],
+                $prefix.'location_type' => [
                     'priority' => 5,
                     'type' => 'select',
                     'label' => 'Location Type',
                     'required' => true,
-                    'class' => array('form-row-wide', 'address-field', 'update_totals_on_change'),
+                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
                     'placeholder' => 'Please select',
                     'options' => $location_types,
                     'default' => 'Private House',
                     'selected' => '',
-                ),
-                $prefix.'company' => array(
+                ],
+                $prefix.'company' => [
                     'priority' => 6,
                     'label' => 'Company Name',
                     'placeholder' => 'Company (optional)',
                     'autocomplete' => 'organization',
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'address_1' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'address_1' => [
                     'priority' => 7,
                     'label' => 'Street',
                     'placeholder' => 'Street number and name.',
                     'autocomplete' => 'address-line1',
                     'required' => true,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'address_2' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'address_2' => [
                     'priority' => 8,
                     'label' => 'Building Details',
                     'placeholder' => 'Apartment, suite, unit etc. (optional)',
-                    'class' => array('form-row-wide'),
+                    'class' => ['form-row-wide'],
                     'autocomplete' => 'address-line2',
                     'required' => false,
-                ),
-                $prefix.'postcode' => array(
+                ],
+                $prefix.'postcode' => [
                     'priority' => 9,
                     'label' => 'Postal Code',
                     'placeholder' => 'Postal Code',
                     'required' => false,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'first_name' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'first_name' => [
                     'priority' => 10,
                     'label' => 'First Name',
                     'placeholder' => 'First Name',
                     'autocomplete' => 'given-name',
                     'required' => true,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'last_name' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'last_name' => [
                     'priority' => 11,
                     'label' => 'Last Name',
                     'placeholder' => 'Last Name',
                     'autocomplete' => 'family-name',
                     'required' => true,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'phone' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'phone' => [
                     'priority' => 12,
-                    'validate' => array('phone'),
+                    'validate' => ['phone'],
                     'label' => 'Cell Phone',
                     'placeholder' => 'Phone number',
                     'required' => true,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'email' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'email' => [
                     'priority' => 13,
-                    'validate' => array('email'),
+                    'validate' => ['email'],
                     'label' => 'Email Address',
                     'placeholder' => 'you@yourdomain.co.za',
                     'required' => true,
-                    'class' => array('form-row-wide'),
-                ),
-                $prefix.'postcode' => array(
+                    'class' => ['form-row-wide'],
+                ],
+                $prefix.'postcode' => [
                     'priority' => 14,
                     'label' => 'Postal Code',
                     'placeholder' => 'Postal Code',
                     'required' => false,
-                    'class' => array('form-row-wide', 'address-field', 'update_totals_on_change'),
-                ),
-            );
+                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
+                ],
+            ];
         } catch (InvalidResourceDataException $e) {
             return $this->defaultFields;
         }

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -9,8 +9,8 @@ class MdsFields
 {
     public static function getFields()
     {
-        return array(
-            'downloadLogs' => array(
+        return [
+            'downloadLogs' => [
                 'title' => __('Clear Cache/Download Error Logs?'),
                 'type' => 'text',
                 'description' => __(
@@ -18,154 +18,154 @@ class MdsFields
                 ),
                 'placeholder' => admin_url().'admin.php?page=mds_download_log_files',
                 'default' => null,
-            ),
-            'enabled' => array(
+            ],
+            'enabled' => [
                 'title' => __('Enabled?'),
                 'type' => 'checkbox',
                 'default' => 'yes',
-            ),
-            'mds_user' => array(
+            ],
+            'mds_user' => [
                 'title' => 'MDS '.__('Username'),
                 'type' => 'text',
                 'description' => __('Email address associated with your MDS account.'),
                 'default' => 'api@collivery.co.za',
-            ),
-            'mds_pass' => array(
+            ],
+            'mds_pass' => [
                 'title' => 'MDS '.__('Password'),
                 'type' => 'text',
                 'description' => __('The password used when logging in to MDS.'),
                 'default' => 'api123',
-            ),
-            'include_product_titles' => array(
+            ],
+            'include_product_titles' => [
                 'title' => __('Include product titles'),
                 'type' => 'checkbox',
                 'description' => __('Includes product titles which appended to the delivery instructions which max characters is 4096'),
                 'default' => 'no',
-            ),
-            'include_order_number' => array(
+            ],
+            'include_order_number' => [
                 'title' => __('Include order number'),
                 'type' => 'checkbox',
                 'description' => __('Includes order number which appended to the delivery instructions which max characters is 4096'),
                 'default' => 'yes',
-            ),
-            'include_customer_note' => array(
+            ],
+            'include_customer_note' => [
                 'title' => __('Include customer note'),
                 'type' => 'checkbox',
                 'description' => __('Includes customer note which appended to the delivery instructions which max characters is 4096'),
                 'default' => 'no',
-            ),
-            'round' => array(
+            ],
+            'round' => [
                 'title' => 'MDS '.__('Round Price'),
                 'type' => 'checkbox',
                 'description' => __('Rounds price up.'),
                 'default' => 'yes',
-            ),
-            'include_vat' => array(
+            ],
+            'include_vat' => [
                 'title' => 'MDS '.__('Use Inclusive Amount'),
                 'type' => 'checkbox',
                 'description' => __('If Woocommerce is setup to add VAT onto the shipping cost then you should uncheck this box to use the exclusive amount, this way VAT will only be applied once. If your not adding VAT onto the shipping cost using Woocommerce then always use the inclusive amount. This option only affects the price displayed on your checkout page, MDS Collivery will always bill you the inclusive amount.'),
                 'default' => 'yes',
-            ),
-            'risk_cover' => array(
+            ],
+            'risk_cover' => [
                 'title' => 'MDS '.__('Risk Cover'),
                 'type' => 'checkbox',
                 'description' => __('Risk cover, up to a maximum of R10 000.'),
                 'default' => 'no',
-            ),
-            'risk_cover_threshold' => array(
+            ],
+            'risk_cover_threshold' => [
                 'title' => __('Risk cover minimum'),
                 'type' => 'decimal',
                 'description' => __('The minimum price of cart items to enable').' MDS '.__(
                         'risk cover, only active when risk cover above is checked<br><strong>Please read the <a href="https://collivery.net/terms" target="_blank">terms and conditions</a> on our website</strong>'
                     ),
                 'default' => 1000.00,
-            ),
-            'fee_exclude_virtual' => array(
+            ],
+            'fee_exclude_virtual' => [
                 'title' => __('Exclude "Virtual" From Calculations'),
                 'type' => 'checkbox',
                 'description' => __('Do not include products marked as "virtual" in the calculation for free/discounted deliveries or towards the "Risk cover minimum".'),
                 'default' => 'no',
-            ),
-            'fee_exclude_downloadable' => array(
+            ],
+            'fee_exclude_downloadable' => [
                 'title' => __('Exclude "Downloadable" From Calculations'),
                 'type' => 'checkbox',
                 'description' => __('Do not include products marked as "downloadable" in the calculation for free/discounted deliveries or towards the "Risk cover minimum".'),
                 'default' => 'no',
-            ),
-            'method_free' => array(
+            ],
+            'method_free' => [
                 'title' => __('Free/Discount Delivery mode'),
                 'type' => 'select',
                 'description' => __('Whether to offer free or discounted deliveries if the cart total exceeds the value of "Free/Discount Delivery Min Total".'),
                 'default' => 'no',
-                'options' => array(
+                'options' => [
                     'no' => __('No free deliveries'),
                     'yes' => __('Free delivery'),
                     'discount' => __('Discount on deliveries'),
-                ),
-            ),
-            'shipping_discount_percentage' => array(
+                ],
+            ],
+            'shipping_discount_percentage' => [
                 'title' => __('Percentage discount for shipping'),
                 'type' => 'number',
                 'description' => __(
                     'The percentage discount that users get when their cart total exceeds <strong>"Free/Discount Delivery Min Total"</strong>'
                 ),
                 'default' => 10,
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'min' => 2,
                     'max' => 100,
                     'step' => 0.1,
-                ),
-            ),
-            'wording_free' => array(
+                ],
+            ],
+            'wording_free' => [
                 'title' => __('Free Delivery Wording'),
                 'type' => 'text',
                 'default' => 'Free Delivery',
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'data-type' => 'free-delivery-item',
-                ),
-            ),
-            'free_min_total' => array(
+                ],
+            ],
+            'free_min_total' => [
                 'title' => __('Free/Discount Delivery Min Total'),
                 'type' => 'number',
                 'description' => __('Minimum order total before free delivery is included, amount is including vat.'),
                 'default' => '1000.00',
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'step' => .1,
                     'min' => 0,
-                ),
-            ),
-            'free_delivery_blacklist' => array(
+                ],
+            ],
+            'free_delivery_blacklist' => [
                 'title' => __('Exclude these roles from free delivery'),
                 'type' => 'text',
                 'description' => __('Comma separated list of roles that must be excluded from free shipping'),
                 'default' => null,
-            ),
-            'free_local_only' => array(
+            ],
+            'free_local_only' => [
                 'title' => __('Free Delivery Local Only'),
                 'type' => 'checkbox',
                 'description' => __('Only allow free delivery for local deliveries only. '),
                 'default' => 'no',
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'data-type' => 'free-delivery-item',
-                ),
-            ),
-            'toggle_automatic_mds_processing' => array(
+                ],
+            ],
+            'toggle_automatic_mds_processing' => [
                 'title' => __('Automatic MDS Processing'),
                 'type' => 'checkbox',
                 'description' => __(
                     'When enabled deliveries for an order will be automatically processed. Please refer to the manual for detailed information on implications on using this <a target="_blank" href="https://github.com/Collivery/Collivery-WooCommerce/">Manual</a>'
                 ),
                 'default' => 'no',
-            ),
-            'auto_accept' => array(
+            ],
+            'auto_accept' => [
                 'title' => __('Auto accept'),
                 'type' => 'checkbox',
                 'description' => __(
                     'After automatic mds processing has sent the request through to MDS, should the request be auto accepted or will you manually accept the delivery on the MDS website'
                 ),
                 'default' => 'yes',
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -175,65 +175,65 @@ class MdsFields
      */
     public static function instanceFields(MdsColliveryService $service)
     {
-        $fields = array();
+        $fields = [];
 
         try {
             $resources = self::getResources($service);
             foreach ($resources['services'] as $id => $title) {
-                $fields['method_'.$id] = array(
+                $fields['method_'.$id] = [
                     'title' => __($title),
                     'type' => 'checkbox',
                     'default' => 'yes',
-                );
-                $fields['fixed_price_'.$id] = array(
+                ];
+                $fields['fixed_price_'.$id] = [
                     'title' => __($title.' Fixed Price Amount'),
                     'type' => 'number',
                     'description' => 'Amount greater than 0 enables it, markup is then ignored. This will override any free or discounted shipping',
                     'default' => '0',
-                    'custom_attributes' => array(
+                    'custom_attributes' => [
                         'step' => 'any',
                         'min' => '0',
-                    ),
-                );
-                $fields['markup_'.$id] = array(
+                    ],
+                ];
+                $fields['markup_'.$id] = [
                     'title' => __($title.' Markup'),
                     'type' => 'number',
                     'default' => '10',
                     'description' => 'Percentage markup you would like to apply to MDS\'s Price',
-                    'custom_attributes' => array(
+                    'custom_attributes' => [
                         'step' => 'any',
                         'min' => '0',
-                    ),
-                );
-                $fields['wording_'.$id] = array(
+                    ],
+                ];
+                $fields['wording_'.$id] = [
                     'title' => __($title.' Wording'),
                     'type' => 'text',
                     'default' => $title,
                     'description' => 'The wording you would like on the checkout page for this service',
                     'class' => 'sectionEnd',
-                );
+                ];
             }
 
-            $fields['free_default_service'] = array(
+            $fields['free_default_service'] = [
                 'title' => __('Free Delivery Default Service'),
                 'type' => 'select',
                 'options' => $resources['services'],
                 'default' => 5,
                 'description' => __('When free delivery is enabled, which default service do we use.'),
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'data-type' => 'free-delivery-item',
-                ),
-            );
-            $fields['free_local_default_service'] = array(
+                ],
+            ];
+            $fields['free_local_default_service'] = [
                 'title' => __('Free Delivery Local Only Default Service'),
                 'type' => 'select',
                 'options' => $resources['services'],
                 'default' => 2,
                 'description' => __('When free local only delivery is enabled, which default service do we use.'),
-                'custom_attributes' => array(
+                'custom_attributes' => [
                     'data-type' => 'free-delivery-item',
-                ),
-            );
+                ],
+            ];
 
             return $fields;
         } catch (InvalidResourceDataException $e) {
@@ -257,7 +257,7 @@ class MdsFields
         $collivery = $service->returnColliveryClass();
 
         try {
-            $resources = array();
+            $resources = [];
             foreach (['towns', 'location_types', 'services'] as $resource) {
                 $result = $collivery->{'get' . str_replace('_', '', ucwords($resource))}();
                 if (!is_array($result)) {

--- a/MdsSupportingClasses/MdsLogger.php
+++ b/MdsSupportingClasses/MdsLogger.php
@@ -44,14 +44,14 @@ class MdsLogger
      * @param $settings
      * @param array $extraData
      */
-    public function error($function, $error, $settings, $extraData = array())
+    public function error($function, $error, $settings, $extraData = [])
     {
-        $this->put('error', array_filter(array(
+        $this->put('error', array_filter([
             'function' => $function,
             'error' => $error,
             'settings' => $settings,
             'data' => $extraData,
-        )));
+        ]));
     }
 
     /**
@@ -60,26 +60,26 @@ class MdsLogger
      * @param $settings
      * @param array $extraData
      */
-    public function warning($function, $error, $settings, $extraData = array())
+    public function warning($function, $error, $settings, $extraData = [])
     {
-        $this->put('warning', array_filter(array(
+        $this->put('warning', array_filter([
             'function' => $function,
             'error' => $error,
             'settings' => $settings,
             'data' => $extraData,
-        )));
+        ]));
     }
 
     /**
      * @param $message
      * @param array $data
      */
-    public function success($message, $data = array())
+    public function success($message, $data = [])
     {
-        $this->put('success', array_filter(array(
+        $this->put('success', array_filter([
             'message' => $message,
             'data' => $data,
-        )));
+        ]));
     }
 
     /**
@@ -102,9 +102,9 @@ class MdsLogger
      */
     public function zipLogFiles()
     {
-        $files = array();
+        $files = [];
 
-        foreach (array('warning', 'error') as $name) {
+        foreach (['warning', 'error'] as $name) {
             if (file_exists($this->getLogDirectory().$name)) {
                 $files[] = $this->getLogDirectory().$name;
             }
@@ -127,7 +127,7 @@ class MdsLogger
 
             return $zip_path;
         } else {
-            $this->error('MdsLogger:zipLogFiles', 'Unable to create zip file', array());
+            $this->error('MdsLogger:zipLogFiles', 'Unable to create zip file', []);
         }
 
         return false;
@@ -175,7 +175,7 @@ class MdsLogger
             }
         }
 
-        if (file_put_contents($this->getLogDirectory().$name, json_encode(array(time() => $value), JSON_PRETTY_PRINT), FILE_APPEND)) {
+        if (file_put_contents($this->getLogDirectory().$name, json_encode([time() => $value], JSON_PRETTY_PRINT), FILE_APPEND)) {
             return true;
         } else {
             return false;

--- a/MdsSupportingClasses/MdsSettings.php
+++ b/MdsSupportingClasses/MdsSettings.php
@@ -14,7 +14,7 @@ class MdsSettings
      */
     public $instanceSettings;
 
-    public function __construct($settings = array(), $instanceSettings = array())
+    public function __construct($settings = [], $instanceSettings = [])
     {
         $this->settings = $settings;
         $this->instanceSettings = $instanceSettings;

--- a/MdsSupportingClasses/ParseDown.php
+++ b/MdsSupportingClasses/ParseDown.php
@@ -31,7 +31,7 @@ class ParseDown
     public function text($text)
     {
         // make sure no definitions are set
-        $this->Definitions = array();
+        $this->Definitions = [];
 
         // standardize line breaks
         $text = str_replace("\r\n", "\n", $text);
@@ -70,42 +70,42 @@ class ParseDown
     //
     // Lines
     //
-    protected $BlockTypes = array(
-        '#' => array('Atx'),
-        '*' => array('Rule', 'List'),
-        '+' => array('List'),
-        '-' => array('Setext', 'Table', 'Rule', 'List'),
-        '0' => array('List'),
-        '1' => array('List'),
-        '2' => array('List'),
-        '3' => array('List'),
-        '4' => array('List'),
-        '5' => array('List'),
-        '6' => array('List'),
-        '7' => array('List'),
-        '8' => array('List'),
-        '9' => array('List'),
-        ':' => array('Table'),
-        '<' => array('Comment', 'Markup'),
-        '=' => array('Setext'),
-        '>' => array('Quote'),
-        '_' => array('Rule'),
-        '`' => array('FencedCode'),
-        '|' => array('Table'),
-        '~' => array('FencedCode'),
-    );
+    protected $BlockTypes = [
+        '#' => ['Atx'],
+        '*' => ['Rule', 'List'],
+        '+' => ['List'],
+        '-' => ['Setext', 'Table', 'Rule', 'List'],
+        '0' => ['List'],
+        '1' => ['List'],
+        '2' => ['List'],
+        '3' => ['List'],
+        '4' => ['List'],
+        '5' => ['List'],
+        '6' => ['List'],
+        '7' => ['List'],
+        '8' => ['List'],
+        '9' => ['List'],
+        ':' => ['Table'],
+        '<' => ['Comment', 'Markup'],
+        '=' => ['Setext'],
+        '>' => ['Quote'],
+        '_' => ['Rule'],
+        '`' => ['FencedCode'],
+        '|' => ['Table'],
+        '~' => ['FencedCode'],
+    ];
 
     // ~
 
-    protected $DefinitionTypes = array(
-        '[' => array('Reference'),
-    );
+    protected $DefinitionTypes = [
+        '[' => ['Reference'],
+    ];
 
     // ~
 
-    protected $unmarkedBlockTypes = array(
+    protected $unmarkedBlockTypes = [
         'CodeBlock',
-    );
+    ];
 
     //
     // Blocks
@@ -134,7 +134,7 @@ class ParseDown
 
             // ~
 
-            $Line = array('body' => $line, 'indent' => $indent, 'text' => $text);
+            $Line = ['body' => $line, 'indent' => $indent, 'text' => $text];
 
             // ~
 
@@ -253,13 +253,13 @@ class ParseDown
 
             $text = trim($Line['text'], '# ');
 
-            $Block = array(
-                'element' => array(
+            $Block = [
+                'element' => [
                     'name' => 'h'.$level,
                     'text' => $text,
                     'handler' => 'line',
-                ),
-            );
+                ],
+            ];
 
             return $Block;
         }
@@ -273,16 +273,16 @@ class ParseDown
         if ($Line['indent'] >= 4) {
             $text = substr($Line['body'], 4);
 
-            $Block = array(
-                'element' => array(
+            $Block = [
+                'element' => [
                     'name' => 'pre',
                     'handler' => 'element',
-                    'text' => array(
+                    'text' => [
                         'name' => 'code',
                         'text' => $text,
-                    ),
-                ),
-            );
+                    ],
+                ],
+            ];
 
             return $Block;
         }
@@ -324,9 +324,9 @@ class ParseDown
     protected function identifyComment($Line)
     {
         if (isset($Line['text'][3]) and $Line['text'][3] === '-' and $Line['text'][2] === '-' and $Line['text'][1] === '!') {
-            $Block = array(
+            $Block = [
                 'element' => $Line['body'],
-            );
+            ];
 
             if (preg_match('/-->$/', $Line['text'])) {
                 $Block['closed'] = true;
@@ -357,27 +357,27 @@ class ParseDown
     protected function identifyFencedCode($Line)
     {
         if (preg_match('/^(['.$Line['text'][0].']{3,})[ ]*([\w-]+)?[ ]*$/', $Line['text'], $matches)) {
-            $Element = array(
+            $Element = [
                 'name' => 'code',
                 'text' => '',
-            );
+            ];
 
             if (isset($matches[2])) {
                 $class = 'language-'.$matches[2];
 
-                $Element['attributes'] = array(
+                $Element['attributes'] = [
                     'class' => $class,
-                );
+                ];
             }
 
-            $Block = array(
+            $Block = [
                 'char' => $Line['text'][0],
-                'element' => array(
+                'element' => [
                     'name' => 'pre',
                     'handler' => 'element',
                     'text' => $Element,
-                ),
-            );
+                ],
+            ];
 
             return $Block;
         }
@@ -424,25 +424,25 @@ class ParseDown
 
     protected function identifyList($Line)
     {
-        list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]+[.]');
+        list($name, $pattern) = $Line['text'][0] <= '-' ? ['ul', '[*+-]'] : ['ol', '[0-9]+[.]'];
 
         if (preg_match('/^('.$pattern.'[ ]+)(.*)/', $Line['text'], $matches)) {
-            $Block = array(
+            $Block = [
                 'indent' => $Line['indent'],
                 'pattern' => $pattern,
-                'element' => array(
+                'element' => [
                     'name' => $name,
                     'handler' => 'elements',
-                ),
-            );
+                ],
+            ];
 
-            $Block['li'] = array(
+            $Block['li'] = [
                 'name' => 'li',
                 'handler' => 'li',
-                'text' => array(
+                'text' => [
                     $matches[2],
-                ),
-            );
+                ],
+            ];
 
             $Block['element']['text'][] = &$Block['li'];
 
@@ -466,13 +466,13 @@ class ParseDown
 
             unset($Block['li']);
 
-            $Block['li'] = array(
+            $Block['li'] = [
                 'name' => 'li',
                 'handler' => 'li',
-                'text' => array(
+                'text' => [
                     $matches[1],
-                ),
-            );
+                ],
+            ];
 
             $Block['element']['text'][] = &$Block['li'];
 
@@ -506,13 +506,13 @@ class ParseDown
     protected function identifyQuote($Line)
     {
         if (preg_match('/^>[ ]?(.*)/', $Line['text'], $matches)) {
-            $Block = array(
-                'element' => array(
+            $Block = [
+                'element' => [
                     'name' => 'blockquote',
                     'handler' => 'lines',
                     'text' => (array) $matches[1],
-                ),
-            );
+                ],
+            ];
 
             return $Block;
         }
@@ -545,11 +545,11 @@ class ParseDown
     protected function identifyRule($Line)
     {
         if (preg_match('/^(['.$Line['text'][0].'])([ ]{0,2}\1){2,}[ ]*$/', $Line['text'])) {
-            $Block = array(
-                'element' => array(
+            $Block = [
+                'element' => [
                     'name' => 'hr',
-                ),
-            );
+                ],
+            ];
 
             return $Block;
         }
@@ -581,9 +581,9 @@ class ParseDown
                 return;
             }
 
-            $Block = array(
+            $Block = [
                 'element' => $Line['body'],
-            );
+            ];
 
             if ($matches[2] or $matches[1] === 'hr' or preg_match('/<\/'.$matches[1].'>[ ]*$/', $Line['text'])) {
                 $Block['closed'] = true;
@@ -629,7 +629,7 @@ class ParseDown
         }
 
         if (strpos($Block['element']['text'], '|') !== false and chop($Line['text'], ' -:|') === '') {
-            $alignments = array();
+            $alignments = [];
 
             $divider = $Line['text'];
 
@@ -660,7 +660,7 @@ class ParseDown
 
             // ~
 
-            $HeaderElements = array();
+            $HeaderElements = [];
 
             $header = $Block['element']['text'];
 
@@ -672,18 +672,18 @@ class ParseDown
             foreach ($headerCells as $index => $headerCell) {
                 $headerCell = trim($headerCell);
 
-                $HeaderElement = array(
+                $HeaderElement = [
                     'name' => 'th',
                     'text' => $headerCell,
                     'handler' => 'line',
-                );
+                ];
 
                 if (isset($alignments[$index])) {
                     $alignment = $alignments[$index];
 
-                    $HeaderElement['attributes'] = array(
+                    $HeaderElement['attributes'] = [
                         'align' => $alignment,
-                    );
+                    ];
                 }
 
                 $HeaderElements[] = $HeaderElement;
@@ -691,31 +691,31 @@ class ParseDown
 
             // ~
 
-            $Block = array(
+            $Block = [
                 'alignments' => $alignments,
                 'identified' => true,
-                'element' => array(
+                'element' => [
                     'name' => 'table',
                     'handler' => 'elements',
-                ),
-            );
+                ],
+            ];
 
-            $Block['element']['text'][] = array(
+            $Block['element']['text'][] = [
                 'name' => 'thead',
                 'handler' => 'elements',
-            );
+            ];
 
-            $Block['element']['text'][] = array(
+            $Block['element']['text'][] = [
                 'name' => 'tbody',
                 'handler' => 'elements',
-                'text' => array(),
-            );
+                'text' => [],
+            ];
 
-            $Block['element']['text'][0]['text'][] = array(
+            $Block['element']['text'][0]['text'][] = [
                 'name' => 'tr',
                 'handler' => 'elements',
                 'text' => $HeaderElements,
-            );
+            ];
 
             return $Block;
         }
@@ -724,7 +724,7 @@ class ParseDown
     protected function addToTable($Line, array $Block)
     {
         if ($Line['text'][0] === '|' or strpos($Line['text'], '|')) {
-            $Elements = array();
+            $Elements = [];
 
             $row = $Line['text'];
 
@@ -736,26 +736,26 @@ class ParseDown
             foreach ($cells as $index => $cell) {
                 $cell = trim($cell);
 
-                $Element = array(
+                $Element = [
                     'name' => 'td',
                     'handler' => 'line',
                     'text' => $cell,
-                );
+                ];
 
                 if (isset($Block['alignments'][$index])) {
-                    $Element['attributes'] = array(
+                    $Element['attributes'] = [
                         'align' => $Block['alignments'][$index],
-                    );
+                    ];
                 }
 
                 $Elements[] = $Element;
             }
 
-            $Element = array(
+            $Element = [
                 'name' => 'tr',
                 'handler' => 'elements',
                 'text' => $Elements,
-            );
+            ];
 
             $Block['element']['text'][1]['text'][] = $Element;
 
@@ -770,12 +770,12 @@ class ParseDown
     protected function identifyReference($Line)
     {
         if (preg_match('/^\[(.+?)\]:[ ]*<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*$/', $Line['text'], $matches)) {
-            $Definition = array(
+            $Definition = [
                 'id' => strtolower($matches[1]),
-                'data' => array(
+                'data' => [
                     'url' => $matches[2],
-                ),
-            );
+                ],
+            ];
 
             if (isset($matches[3])) {
                 $Definition['data']['title'] = $matches[3];
@@ -791,13 +791,13 @@ class ParseDown
 
     protected function buildParagraph($Line)
     {
-        $Block = array(
-            'element' => array(
+        $Block = [
+            'element' => [
                 'name' => 'p',
                 'text' => $Line['text'],
                 'handler' => 'line',
-            ),
-        );
+            ],
+        ];
 
         return $Block;
     }
@@ -862,18 +862,18 @@ class ParseDown
     // Spans
     //
 
-    protected $SpanTypes = array(
-        '!' => array('Link'), // ?
-        '&' => array('Ampersand'),
-        '*' => array('Emphasis'),
-        '/' => array('Url'),
-        '<' => array('UrlTag', 'EmailTag', 'Tag', 'LessThan'),
-        '[' => array('Link'),
-        '_' => array('Emphasis'),
-        '`' => array('InlineCode'),
-        '~' => array('Strikethrough'),
-        '\\' => array('EscapeSequence'),
-    );
+    protected $SpanTypes = [
+        '!' => ['Link'], // ?
+        '&' => ['Ampersand'],
+        '*' => ['Emphasis'],
+        '/' => ['Url'],
+        '<' => ['UrlTag', 'EmailTag', 'Tag', 'LessThan'],
+        '[' => ['Link'],
+        '_' => ['Emphasis'],
+        '`' => ['InlineCode'],
+        '~' => ['Strikethrough'],
+        '\\' => ['EscapeSequence'],
+    ];
 
     // ~
 
@@ -896,7 +896,7 @@ class ParseDown
 
             $markerPosition += strpos($remainder, $marker);
 
-            $Excerpt = array('text' => $excerpt, 'context' => $text);
+            $Excerpt = ['text' => $excerpt, 'context' => $text];
 
             foreach ($this->SpanTypes[$marker] as $spanType) {
                 $handler = 'identify'.$spanType;
@@ -955,29 +955,29 @@ class ParseDown
         }
 
         if (preg_match('/\bhttps?:[\/]{2}[^\s<]+\b\/*/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)) {
-            $url = str_replace(array('&', '<'), array('&amp;', '&lt;'), $matches[0][0]);
+            $url = str_replace(array('&', '<'), ['&amp;', '&lt;'], $matches[0][0]);
 
-            return array(
+            return [
                 'extent' => strlen($matches[0][0]),
                 'position' => $matches[0][1],
-                'element' => array(
+                'element' => [
                     'name' => 'a',
                     'text' => $url,
-                    'attributes' => array(
+                    'attributes' => [
                         'href' => $url,
-                    ),
-                ),
-            );
+                    ],
+                ],
+            ];
         }
     }
 
     protected function identifyAmpersand($Excerpt)
     {
         if (!preg_match('/^&#?\w+;/', $Excerpt['text'])) {
-            return array(
+            return [
                 'markup' => '&amp;',
                 'extent' => 1,
-            );
+            ];
         }
     }
 
@@ -988,33 +988,33 @@ class ParseDown
         }
 
         if ($Excerpt['text'][1] === '~' and preg_match('/^~~(?=\S)(.+?)(?<=\S)~~/', $Excerpt['text'], $matches)) {
-            return array(
+            return [
                 'extent' => strlen($matches[0]),
-                'element' => array(
+                'element' => [
                     'name' => 'del',
                     'text' => $matches[1],
                     'handler' => 'line',
-                ),
-            );
+                ],
+            ];
         }
     }
 
     protected function identifyEscapeSequence($Excerpt)
     {
         if (isset($Excerpt['text'][1]) and in_array($Excerpt['text'][1], $this->specialCharacters)) {
-            return array(
+            return [
                 'markup' => $Excerpt['text'][1],
                 'extent' => 2,
-            );
+            ];
         }
     }
 
     protected function identifyLessThan()
     {
-        return array(
+        return [
             'markup' => '&lt;',
             'extent' => 1,
-        );
+        ];
     }
 
     protected function identifyUrlTag($Excerpt)
@@ -1025,44 +1025,44 @@ class ParseDown
                 $matches
             )
         ) {
-            $url = str_replace(array('&', '<'), array('&amp;', '&lt;'), $matches[1]);
+            $url = str_replace(['&', '<'], ['&amp;', '&lt;'], $matches[1]);
 
-            return array(
+            return [
                 'extent' => strlen($matches[0]),
-                'element' => array(
+                'element' => [
                     'name' => 'a',
                     'text' => $url,
-                    'attributes' => array(
+                    'attributes' => [
                         'href' => $url,
-                    ),
-                ),
-            );
+                    ],
+                ],
+            ];
         }
     }
 
     protected function identifyEmailTag($Excerpt)
     {
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\S+?@\S+?)>/', $Excerpt['text'], $matches)) {
-            return array(
+            return [
                 'extent' => strlen($matches[0]),
-                'element' => array(
+                'element' => [
                     'name' => 'a',
                     'text' => $matches[1],
-                    'attributes' => array(
+                    'attributes' => [
                         'href' => 'mailto:'.$matches[1],
-                    ),
-                ),
-            );
+                    ],
+                ],
+            ];
         }
     }
 
     protected function identifyTag($Excerpt)
     {
         if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<\/?\w.*?>/', $Excerpt['text'], $matches)) {
-            return array(
+            return [
                 'markup' => $matches[0],
                 'extent' => strlen($matches[0]),
-            );
+            ];
         }
     }
 
@@ -1078,13 +1078,13 @@ class ParseDown
             $text = $matches[2];
             $text = htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8');
 
-            return array(
+            return [
                 'extent' => strlen($matches[0]),
-                'element' => array(
+                'element' => [
                     'name' => 'code',
                     'text' => $text,
-                ),
-            );
+                ],
+            ];
         }
     }
 
@@ -1093,7 +1093,7 @@ class ParseDown
         $extent = $Excerpt['text'][0] === '!' ? 1 : 0;
 
         if (strpos($Excerpt['text'], ']') and preg_match('/\[((?:[^][]|(?R))*)\]/', $Excerpt['text'], $matches)) {
-            $Link = array('text' => $matches[1], 'label' => strtolower($matches[1]));
+            $Link = ['text' => $matches[1], 'label' => strtolower($matches[1])];
 
             $extent += strlen($matches[0]);
 
@@ -1130,35 +1130,35 @@ class ParseDown
             return;
         }
 
-        $url = str_replace(array('&', '<'), array('&amp;', '&lt;'), $Link['url']);
+        $url = str_replace(['&', '<'], ['&amp;', '&lt;'], $Link['url']);
 
         if ($Excerpt['text'][0] === '!') {
-            $Element = array(
+            $Element = [
                 'name' => 'img',
-                'attributes' => array(
+                'attributes' => [
                     'alt' => $Link['text'],
                     'src' => $url,
-                ),
-            );
+                ],
+            ];
         } else {
-            $Element = array(
+            $Element = [
                 'name' => 'a',
                 'handler' => 'line',
                 'text' => $Link['text'],
-                'attributes' => array(
+                'attributes' => [
                     'href' => $url,
-                ),
-            );
+                ],
+            ];
         }
 
         if (isset($Link['title'])) {
             $Element['attributes']['title'] = $Link['title'];
         }
 
-        return array(
+        return [
             'extent' => $extent,
             'element' => $Element,
-        );
+        ];
     }
 
     protected function identifyEmphasis($Excerpt)
@@ -1177,14 +1177,14 @@ class ParseDown
             return;
         }
 
-        return array(
+        return [
             'extent' => strlen($matches[0]),
-            'element' => array(
+            'element' => [
                 'name' => $emphasis,
                 'handler' => 'line',
                 'text' => $matches[1],
-            ),
-        );
+            ],
+        ];
     }
 
     //
@@ -1238,7 +1238,7 @@ class ParseDown
         return $instance;
     }
 
-    private static $instances = array();
+    private static $instances = [];
 
     //
     // Deprecated Methods
@@ -1263,21 +1263,21 @@ class ParseDown
     //
     // Read-only
 
-    protected $specialCharacters = array(
+    protected $specialCharacters = [
         '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!',
-    );
+    ];
 
-    protected $StrongRegex = array(
+    protected $StrongRegex = [
         '*' => '/^[*]{2}((?:[^*]|[*][^*]*[*])+?)[*]{2}(?![*])/s',
         '_' => '/^__((?:[^_]|_[^_]*_)+?)__(?!_)/us',
-    );
+    ];
 
-    protected $EmRegex = array(
+    protected $EmRegex = [
         '*' => '/^[*]((?:[^*]|[*][*][^*]+?[*][*])+?)[*](?![*])/s',
         '_' => '/^_((?:[^_]|__[^_]*__)+?)_(?!_)\b/us',
-    );
+    ];
 
-    protected $textLevelElements = array(
+    protected $textLevelElements = [
         'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont',
         'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',
         'i', 'rp', 'del', 'code', 'strike', 'marquee',
@@ -1287,5 +1287,5 @@ class ParseDown
         'var', 'ruby',
         'wbr', 'span',
         'time',
-    );
+    ];
 }

--- a/MdsSupportingClasses/ShippingPackageData.php
+++ b/MdsSupportingClasses/ShippingPackageData.php
@@ -54,10 +54,10 @@ class ShippingPackageData
         }
 
         $extractedFields = $this->extractRequiredFields($input, $packages);
-        $requiredFields = (object) array(
+        $requiredFields = (object) [
             'to_town_id' => $this->getTownId($extractedFields),
             'to_town_type' => $this->getLocationType($extractedFields)
-        );
+        ];
 
         if (!isset($requiredFields->to_town_id) || ($requiredFields->to_town_id == '')) {
             return $packages;
@@ -72,14 +72,14 @@ class ShippingPackageData
         $package['free_local_only'] = $this->settings->getValue('free_local_only');
         $package['shipping_cart_total'] = $this->getShippingCartTotal();
 
-        $package['destination'] = array(
+        $package['destination'] = [
             'from_town_id' => (int) $defaults['address']['town_id'],
             'from_location_type' => (int) $defaults['address']['location_type'],
             'city' => $requiredFields->to_town_id,
             'to_town_id' => (int) array_search($requiredFields->to_town_id, $towns),
             'to_location_type' => (int) array_search($requiredFields->to_town_type, $location_types),
             'country' => 'ZA',
-        );
+        ];
 
         $customer = WC ()->customer;
         if ( !isset($_POST['ship_to_different_address']) || $_POST['ship_to_different_address'] != true) {

--- a/MdsSupportingClasses/ShippingPackageData.php
+++ b/MdsSupportingClasses/ShippingPackageData.php
@@ -101,11 +101,11 @@ class ShippingPackageData
         if ($this->shouldBeFree() && !$this->applyFreeDeliveryBlacklist()) {
             $package['service'] = 'free';
             if ($this->settings->getValue('free_local_only') == 'yes') {
-                $data = array(
+                $data = [
                         'num_package' => 1,
                         'service' => 2,
                         'exclude_weekend' => 1,
-                    ) + $package['destination'];
+                    ] + $package['destination'];
 
                 // Query the API to test if this is a local delivery
                 $response = $this->collivery->getPrice($data);

--- a/MdsSupportingClasses/UnitConverter.php
+++ b/MdsSupportingClasses/UnitConverter.php
@@ -4,38 +4,38 @@ namespace MdsSupportingClasses;
 
 class UnitConverter
 {
-    public $conversion_table = array();
+    public $conversion_table = [];
     public $decimal_point;
     public $thousand_separator;
-    public $bases = array();
+    public $bases = [];
 
     public function __construct()
     {
         // Kilogramme, Gramme, Milligramme, Pounds, Ounce
         // Metres, Centimetres, Millimetres, Yards, Foot, Inches
-        $conversions = array(
-            'Weight' => array(
+        $conversions = [
+            'Weight' => [
                 'base' => 'kg',
-                'conv' => array(
+                'conv' => [
                     'g' => 1000,
                     'mg' => 1000000,
                     't' => 0.001,
                     'oz' => 35.274,
                     'lb' => 2.2046,
-                ),
-            ),
-            'Distance' => array(
+                ],
+            ],
+            'Distance' => [
                 'base' => 'km',
-                'conv' => array(
+                'conv' => [
                     'm' => 1000,
                     'cm' => 100000,
                     'mm' => 1000000,
                     'in' => 39370,
                     'ft' => 3280.8,
                     'yd' => 1093.6,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         foreach ($conversions as $key => $val) {
             $this->addConversion($val['base'], $val['conv']);
@@ -59,9 +59,9 @@ class UnitConverter
      * Adds a conversion ratio to the conversion table.
      *
      * @param string  the name of unit from which to convert
-     * @param array   array(
-     *       "pound"=>array("ratio"=>'', "offset"=>'')
-     *        )
+     * @param array   [
+     *           "pound"=>["ratio"=>'', "offset"=>'']
+     *        ]
      *        "pound" - name of unit to set conversion ration to
      *        "ratio" - 'double' conversion ratio which, when
      *        multiplied by the number of $from_unit units produces
@@ -82,24 +82,24 @@ class UnitConverter
                         $this->bases[$from_unit][] = $to_unit;
 
                         if (!is_array($val)) {
-                            $this->conversion_table[$from_unit.'_'.$to_unit] = array('ratio' => $val, 'offset' => 0);
+                            $this->conversion_table[$from_unit.'_'.$to_unit] = ['ratio' => $val, 'offset' => 0];
                         } else {
-                            $this->conversion_table[$from_unit.'_'.$to_unit] = array(
+                            $this->conversion_table[$from_unit.'_'.$to_unit] = [
                                 'ratio' => $val['ratio'],
                                 'offset' => (isset($val['offset']) ? $val['offset'] : 0),
-                            );
+                            ];
                         }
                     }
                 } else {
                     $this->bases[$from_unit][] = $key;
 
                     if (!is_array($val)) {
-                        $this->conversion_table[$from_unit.'_'.$key] = array('ratio' => $val, 'offset' => 0);
+                        $this->conversion_table[$from_unit.'_'.$key] = ['ratio' => $val, 'offset' => 0];
                     } else {
-                        $this->conversion_table[$from_unit.'_'.$key] = array(
+                        $this->conversion_table[$from_unit.'_'.$key] = [
                             'ratio' => $val['ratio'],
                             'offset' => (isset($val['offset']) ? $val['offset'] : 0),
-                        );
+                        ];
                     }
                 }
             }
@@ -139,9 +139,9 @@ class UnitConverter
      * "base" unit being that one that has the highest hierarchical order in one
      * "logical" Conversion_Array
      * when taking $conv->addConversion('km',
-     * array('meter'=>1000, 'dmeter'=>10000, 'centimeter'=>100000,
+     * ['meter'=>1000, 'dmeter'=>10000, 'centimeter'=>100000,
      * 'millimeter'=>1000000, 'mile'=>0.62137, 'naut.mile'=>0.53996,
-     * 'inch(es)/zoll'=>39370, 'ft/foot/feet'=>3280.8, 'yd/yard'=>1093.6));
+     * 'inch(es)/zoll'=>39370, 'ft/foot/feet'=>3280.8, 'yd/yard'=>1093.6]);
      * "km" would be the logical base unit for all units of dinstance, thus,
      * if the function fails to find a direct or reverse conversion in the table
      * it is only logical to suspect that if there is a chance

--- a/Views/index.php
+++ b/Views/index.php
@@ -38,7 +38,7 @@
                     <tr <?php if ($count % 2 == 0) {
                         echo ' class="alt" ';
                     } ?>>
-                        <td><?php echo $order->id; ?></td>
+                        <td><?php echo $order->get_id(); ?></td>
                         <td><a href="<?php echo get_admin_url().'admin.php?page=mds_confirmed&waybill='.$order->waybill; ?>"><?php echo $order->waybill; ?></a></td>
                         <td><?php echo $validation_results->cust_ref; ?></td>
                         <td><?php echo $services[$validation_results->service]; ?></td>

--- a/Views/order.php
+++ b/Views/order.php
@@ -24,22 +24,23 @@ use MdsSupportingClasses\View;
         <table width="100%">
             <tr>
                 <td style="min-width:30%; max-width:35%; vertical-align: top; padding: 0 10px;">
-                    <?php echo View::make('_address_fields', array(
+                    <?php echo View::make('_address_fields', [
                         'prefix' => 'collection',
-                        'towns' => array('' => 'Select Town') + $towns,
-                        'location_types' => array('' => 'Select Location Type') + $location_types,
-                        'suburbs' => array('' => 'Select Suburb') + $suburbs,
-                        'contacts' => array('' => 'Select Contact') + $defaults['contacts'],
-                        'addresses' => array('' => 'Select Address') + $addresses,
+                        'towns' => ['' => 'Select Town'] + $towns,
+                        'location_types' => ['' => 'Select Location Type'] + $location_types,
+                        'suburbs' => ['' => 'Select Suburb'] + $suburbs,
+                        'contacts' => ['' => 'Select Contact'] + $defaults['contacts'],
+                        'addresses' => ['' => 'Select Address'] + $addresses,
                         'default_address_id' => $defaults['default_address_id'],
-                    )); ?>
+                        'order' => $order,
+                    ]); ?>
                 </td>
                 <td style="min-width:20%; max-width:40%; vertical-align: top; padding: 0 10px;">
                     <h3>Parcel's / Instructions / Service</h3>
-                    <?php echo View::make('_parcel_fields', array(
+                    <?php echo View::make('_parcel_fields', [
                         'include_product_titles' => $include_product_titles,
                         'parcels' => $parcels,
-                    )); ?>
+                    ]); ?>
                     <hr />
                     <?php echo View::make('_service_fields', compact('services', 'shipping_method')); ?>
                     <hr />
@@ -57,15 +58,15 @@ use MdsSupportingClasses\View;
                     <input type="text" name="collection_time" id="datetimepicker4" value=""/><hr />
                 </td>
                 <td style="min-width:30%; max-width:35%; vertical-align: top; padding: 0 10px;">
-                    <?php echo View::make('_address_fields', array(
+                    <?php echo View::make('_address_fields', [
                         'prefix' => 'delivery',
-                        'towns' => array('' => 'Select Town') + $towns,
-                        'location_types' => array('' => 'Select Location Type') + $location_types,
-                        'suburbs' => array('' => 'Select Suburb') + $populatedSuburbs,
+                        'towns' => ['' => 'Select Town'] + $towns,
+                        'location_types' => ['' => 'Select Location Type'] + $location_types,
+                        'suburbs' => ['' => 'Select Suburb'] + $populatedSuburbs,
                         'order' => $order,
-                        'contacts' => array('' => 'Select Address First'),
-                        'addresses' => array('' => 'Select Address') + $addresses,
-                    )); ?>
+                        'contacts' => ['' => 'Select Address First'],
+                        'addresses' => ['' => 'Select Address'] + $addresses,
+                    ]); ?>
                 </td>
             </tr>
         </table>
@@ -84,5 +85,5 @@ use MdsSupportingClasses\View;
 <div id="api_results"></div>
 
 <?php
-    echo View::make('_parcel_template', array('include_product_titles' => '$include_product_titles'));
+    echo View::make('_parcel_template', ['include_product_titles' => '$include_product_titles']);
 ?>

--- a/Views/order.php
+++ b/Views/order.php
@@ -3,7 +3,7 @@ use MdsSupportingClasses\View;
 
 ?>
 
-<p>
+<div>
     <b>Please Note:</b>
     <ul>
         <li>
@@ -16,7 +16,7 @@ use MdsSupportingClasses\View;
             changes.
         </li>
     </ul>
-</p>
+</div>
 
 <form accept-charset="UTF-8" action="<?php echo admin_url('post.php?post='.$order->get_id().'&action=edit'); ?>" method="post" id="api_quote">
     <input type="hidden" name="order_id" value="<?php echo $order->get_id(); ?>">

--- a/Views/order.php
+++ b/Views/order.php
@@ -46,11 +46,11 @@ use MdsSupportingClasses\View;
                     <hr />
                     <label for="cover">Risk Cover</label>
                     <label>
-                        <input id="cover" name="cover" type="radio" value="0"<?= !$riskCover ? ' checked="checked"' : '' ?>>
+                        <input id="cover" name="cover" type="radio" value="0"<?php echo (!$riskCover ? ' checked="checked"' : '') ?>>
                         Up to R1000 - default
                     </label>
                     <label>
-                        <input id="cover" name="cover" type="radio" value="1"<?= $riskCover ? ' checked="checked"' : '' ?>>
+                        <input id="cover" name="cover" type="radio" value="1"<?php echo ($riskCover ? ' checked="checked"' : '') ?>>
                         Up to R10,000
                     </label>
                     <hr />

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -50,15 +50,15 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
         $this->admin_page_heading = __('MDS Collivery shipping');
         $this->admin_page_description = __('Seamlessly integrate your website with MDS Collivery');
 
-        $this->supports = array(
+        $this->supports = [
             'settings',
             'shipping-zones',
             'instance-settings',
-        );
+        ];
 
         $this->init();
 
-        add_action('woocommerce_update_options_shipping_'.$this->id, array($this, 'process_admin_options'));
+        add_action('woocommerce_update_options_shipping_'.$this->id, [$this, 'process_admin_options']);
     }
 
     /**
@@ -76,7 +76,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
 
         $this->enabled = $this->mdsSettings->getValue('enabled', $this->enabled);
 
-        add_action('woocommerce_update_options_shipping_'.$this->id, array($this, 'process_admin_options'));
+        add_action('woocommerce_update_options_shipping_'.$this->id, [$this, 'process_admin_options']);
     }
 
     /**
@@ -114,7 +114,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
      *
      * @throws InvalidResourceDataException
      */
-    public function calculate_shipping($package = array())
+    public function calculate_shipping($package = [])
     {
         if (isset($package['destination']['from_town_id']) && $this->collivery_service->validPackage($package)) {
             if (isset($package['service']) && $package['service'] == 'free') {
@@ -125,11 +125,11 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                 }
 
 	            $this->id = $id;
-                $this->add_rate(array(
+                $this->add_rate([
                     'id' => $id,
                     'label' => $this->mdsSettings->getInstanceValue('wording_free', 'Free Delivery'),
                     'cost' => 0.0,
-                ));
+                ]);
             } elseif (!isset($package['service']) || (isset($package['service']) && $package['service'] != 'free')) {
                 try {
                     $services = $this->collivery->getServices();
@@ -146,7 +146,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     $riskCover = 1;
                                 }
 
-                                $data = array(
+                                $data = [
                                     'to_town_id' => $package['destination']['to_town_id'],
                                     'from_town_id' => $package['destination']['from_town_id'],
                                     'to_location_type' => $package['destination']['to_location_type'],
@@ -157,7 +157,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     'parcels' => $package['cart']['products'],
                                     'exclude_weekend' => 1,
                                     'service' => $id,
-                                );
+                                ];
 
                                 $price = $this->collivery_service->getPrice($data, $adjustedTotal, $this->mdsSettings->getInstanceValue( 'markup_' . $id), $this->mdsSettings->getInstanceValue( 'fixed_price_' . $id));
 
@@ -173,12 +173,12 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     $label .= ' - FREE!';
                                 }
                                 $this->id = 'mds_'.$id;
-                                $this->add_rate(array(
+                                $this->add_rate([
                                     'id' => 'mds_'.$id,
                                     'value' => $id,
                                     'label' => $label,
                                     'cost' => $price,
-                                ));
+                                ]);
                             }
                         }
                     }
@@ -213,10 +213,10 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                 $error = 'Your MDS Username is not a valid email address, unable to save your Your MDS Username or Password';
             } else {
                 $newAuthentication = $this->collivery->isNewInstanceAuthenticated(
-                    array(
+                    [
                         'email' => $postData[$this->plugin_id.$this->id.'_mds_user'],
                         'password' => $postData[$this->plugin_id.$this->id.'_mds_pass'],
-                    )
+                    ]
                 );
                 try {
                     if (!$newAuthentication) {

--- a/autoload.php
+++ b/autoload.php
@@ -5,7 +5,7 @@ class MdsColliveryAutoLoader
     /**
      * @var array
      */
-    protected static $classMap = array(
+    protected static $classMap = [
         'MdsCollivery' => '\MdsSupportingClasses\Collivery',
         'EnvironmentInformationBag' => '\MdsSupportingClasses\EnvironmentInformationBag',
         'GitHubPluginUpdater' => '\MdsSupportingClasses\GitHubPluginUpdater',
@@ -25,7 +25,7 @@ class MdsColliveryAutoLoader
         'InvalidServiceException' => '\MdsExceptions\InvalidServiceException',
         'OrderAlreadyProcessedException' => '\MdsExceptions\OrderAlreadyProcessedException',
         'ProductOutOfStockException' => '\MdsExceptions\ProductOutOfStockException',
-    );
+    ];
 
     /**
      * @param $class

--- a/collivery.php
+++ b/collivery.php
@@ -78,7 +78,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          */
         function load_js()
         {
-            wp_register_script('mds_js', plugins_url('script.js', __FILE__), array('jquery'), MDS_VERSION);
+            wp_register_script('mds_js', plugins_url('script.js', __FILE__), ['jquery'], MDS_VERSION);
             wp_enqueue_script('mds_js');
         }
 

--- a/collivery.php
+++ b/collivery.php
@@ -3,14 +3,14 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.5.1');
+define('MDS_VERSION', '3.5.2');
 include 'autoload.php';
 
 /*
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.5.1
+ * Version: 3.5.2
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -49,7 +49,7 @@ function mds_download_log_files()
         readfile($file);
         exit;
     } else {
-        echo View::make('document_not_found', array('url' => get_admin_url().'admin.php?page=wc-settings&tab=shipping&section=mds_collivery', 'urlText' => 'Back to MDS Settings Page'));
+        echo View::make('document_not_found', ['url' => get_admin_url().'admin.php?page=wc-settings&tab=shipping&section=mds_collivery', 'urlText' => 'Back to MDS Settings Page']);
     }
 }
 
@@ -163,14 +163,14 @@ function mds_confirmed_order()
     $collection_contacts = $collivery->getContacts($validation_results->collivery_from);
     $destination_contacts = $collivery->getContacts($validation_results->collivery_to);
 
-    $closedStatusList = array(
+    $closedStatusList = [
         '6' => 'Invoiced',
         '8' => 'Delivered',
         '20' => 'POD Received',
         '4' => 'Quote Rejected',
         '28' => 'Credited',
         '5' => 'Cancelled',
-    );
+    ];
 
     if (isset($closedStatusList[$tracking['status_id']])) {
         $wpdb->query($wpdb->prepare(
@@ -217,7 +217,7 @@ function mds_confirmed_order_view_pdf()
     }
 
     if ($mds->getColliveryErrors()) {
-        echo View::make('document_not_found', array('url' => get_admin_url().'admin.php?page=mds_confirmed&waybill='.$waybill_number, 'urlText' => 'Back to MDS Confirmed Page'));
+        echo View::make('document_not_found', ['url' => get_admin_url().'admin.php?page=mds_confirmed&waybill='.$waybill_number, 'urlText' => 'Back to MDS Confirmed Page']);
     } else {
         header('Content-Type: application/pdf');
         header('Content-Length: '.$file['size']);
@@ -274,19 +274,19 @@ function suburbs_admin_callback()
         $collivery = $mds->returnColliveryClass();
         $fields = $collivery->getSuburbs($_POST['town']);
         if (!empty($fields)) {
-            wp_die(View::make('_options', array(
+            wp_die(View::make('_options', [
                 'fields' => $fields,
                 'placeholder' => 'Select suburb',
-            )));
+            ]));
         } else {
-            wp_die(View::make('_options', array(
+            wp_die(View::make('_options', [
                 'placeholder' => 'Error retrieving data from server. Please try again later...',
-            )));
+            ]));
         }
     } else {
-        wp_die(View::make('_options', array(
+        wp_die(View::make('_options', [
             'placeholder' => 'First Select Town...',
-        )));
+        ]));
     }
 }
 
@@ -303,19 +303,19 @@ function contacts_admin_callback()
         $collivery = $mds->returnColliveryClass();
         $fields = $collivery->getContacts($_POST['address_id']);
         if (!empty($fields)) {
-            wp_die(View::make('_options', array(
+            wp_die(View::make('_options', [
                 'fields' => $fields,
                 'placeholder' => 'Select contact',
-            )));
+            ]));
         } else {
-            wp_die(View::make('_options', array(
+            wp_die(View::make('_options', [
                 'placeholder' => 'Error retrieving data from server. Please try again later...',
-            )));
+            ] ));
         }
     } else {
-        wp_die(View::make('_options', array(
+        wp_die(View::make('_options', [
             'placeholder' => 'First select address...',
-        )));
+        ] ));
     }
 }
 
@@ -336,13 +336,13 @@ function quote_admin_callback()
     $post = $_POST;
 
     // Now lets get the price for
-    $data = array(
+    $data = [
         'num_package' => count($post['parcels']),
         'service' => $post['service'],
         'parcels' => $post['parcels'],
         'exclude_weekend' => 1,
         'cover' => $post['cover'],
-    );
+    ];
 
     // Check which collection address we using
     if ($post['which_collection_address'] == 'default') {
@@ -365,7 +365,7 @@ function quote_admin_callback()
     try {
         $response = $collivery->getPrice($data);
         if (!isset($response['service'])) {
-            throw new InvalidColliveryDataException('Unable to get response from MDS API', 'quote_admin_callback', $mds->loggerSettingsArray(), array('data' => $data, 'errors' => $mds->getColliveryErrors()));
+            throw new InvalidColliveryDataException('Unable to get response from MDS API', 'quote_admin_callback', $mds->loggerSettingsArray(), ['data' => $data, 'errors' => $mds->getColliveryErrors()]);
         }
 
         wp_die('<p class="mds_response"><b>Service: </b>'.$services[$response['service']].' - Price incl: R'.$response['price']['inc_vat'].'</p>');
@@ -394,7 +394,7 @@ function accept_admin_callback()
         if (!$mds->hasOrderBeenProcessed($order->get_id())) {
             // Check which collection address we using and if we need to add the address to collivery api
             if ($post['which_collection_address'] == 'default') {
-                $collection_address = $mds->addColliveryAddress(array(
+                $collection_address = $mds->addColliveryAddress([
                     'company_name' => ($post['collection_company_name'] != '') ? $post['collection_company_name'] : 'Private',
                     'building' => $post['collection_building_details'],
                     'street' => $post['collection_street'],
@@ -405,14 +405,14 @@ function accept_admin_callback()
                     'phone' => preg_replace('/[^0-9]/', '', $post['collection_phone']),
                     'cellphone' => preg_replace('/[^0-9]/', '', $post['collection_cellphone']),
                     'email' => $post['collection_email'],
-                ));
+                ]);
 
                 // Check for any problems
                 if ($collivery->hasErrors()) {
-                    wp_send_json(array(
+                    wp_send_json([
                         'redirect' => false,
                         'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                    ));
+                    ]);
                 } else {
                     // set the collection address and contact from the returned array
                     $collivery_from = $collection_address['address_id'];
@@ -425,7 +425,7 @@ function accept_admin_callback()
 
             // Check which delivery address we using and if we need to add the address to collivery api
             if ($post['which_delivery_address'] == 'default') {
-                $delivery_address = $mds->addColliveryAddress(array(
+                $delivery_address = $mds->addColliveryAddress([
                     'company_name' => ($post['delivery_company_name'] != '') ? $post['delivery_company_name'] : 'Private',
                     'building' => $post['delivery_building_details'],
                     'street' => $post['delivery_street'],
@@ -437,14 +437,14 @@ function accept_admin_callback()
                     'cellphone' => preg_replace('/[^0-9]/', '', $post['delivery_cellphone']),
                     'email' => $post['delivery_email'],
                     'custom_id' => $order->get_user_id(),
-                ));
+                ]);
 
                 // Check for any problems
                 if ($collivery->hasErrors()) {
-                    wp_send_json(array(
+                    wp_send_json([
                         'redirect' => false,
                         'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                    ));
+                    ]);
                 } else {
                     $collivery_to = $delivery_address['address_id'];
                     $contact_to = $delivery_address['contact_id'];
@@ -454,7 +454,7 @@ function accept_admin_callback()
                 $contact_to = $post['contact_to'];
             }
 
-            $collivery_id = $mds->addCollivery(array(
+            $collivery_id = $mds->addCollivery([
                 'collivery_from' => $collivery_from,
                 'contact_from' => $contact_from,
                 'collivery_to' => $collivery_to,
@@ -467,16 +467,16 @@ function accept_admin_callback()
                 'collection_time' => strtotime($post['collection_time']),
                 'parcel_count' => count($post['parcels']),
                 'parcels' => $post['parcels'],
-            ));
+            ]);
 
             // Check for any problems validating
             if (!$collivery_id) {
                 $mds->updateStatusOrAddNote($order, 'There was a problem sending this the delivery request to MDS Collivery, you will need to manually process.', true, 'processing');
 
-                wp_send_json(array(
+                wp_send_json([
                     'redirect' => false,
                     'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                ));
+                ]);
             } else {
                 $validatedData = $mds->returnColliveryValidatedData();
                 $collection_time = (isset($validatedData['collection_time'])) ? ' anytime from: '.date('Y-m-d H:i', $validatedData['collection_time']) : '';
@@ -486,22 +486,22 @@ function accept_admin_callback()
                 $message = 'Order has been sent to MDS Collivery, Waybill Number: '.$collivery_id.', please have order ready for collection'.$collection_time.'.';
                 $mds->updateStatusOrAddNote($order, $message, false, 'completed');
 
-                wp_send_json(array(
+                wp_send_json([
                     'redirect' => true,
                     'message' => '<p class="mds_response">'.$message.' You will be redirect to your order in 5 seconds.</p>',
-                ));
+                ]);
             }
         } else {
-            wp_send_json(array(
+            wp_send_json([
                 'redirect' => false,
                 'message' => '<p class="mds_response">Sorry, this order has already been processed.</p>',
-            ));
+            ]);
         }
     } catch (Exception $e) {
-        wp_send_json(array(
+        wp_send_json([
             'redirect' => false,
             'message' => '<p class="mds_response">'.$e->getMessage().'</p>',
-        ));
+        ]);
     }
 }
 
@@ -597,7 +597,7 @@ function mds_register_collivery()
     $towns = $collivery->getTowns();
     $services = $collivery->getServices();
     $location_types = $collivery->getLocationTypes();
-    $suburbs = array(0=> 'Select Town');
+    $suburbs = [0 => 'Select Town'];
     $populatedSuburbs = $suburbs + $collivery->getSuburbs(array_search($order->get_shipping_city(), $collivery->getTowns()));
 
     $shipping_method = null;

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -1,6 +1,7 @@
 <?php
 
 use MdsExceptions\InvalidColliveryDataException;
+use MdsSupportingClasses\MdsColliveryService;
 use MdsSupportingClasses\View;
 
 /*******************************************************************************
@@ -38,7 +39,7 @@ function mds_admin_menu()
  */
 function mds_download_log_files()
 {
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     if ($file = $mds->downloadLogFiles()) {
         $file_name = basename($file);
@@ -58,7 +59,7 @@ function mds_download_log_files()
  */
 function mds_clear_cache_files()
 {
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $cache = $mds->returnCacheClass();
     $cache->delete();
@@ -98,7 +99,7 @@ function mds_confirmed_orders()
         OBJECT);
     }
 
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $services = $mds->returnColliveryClass()->getServices();
     echo View::make('index', compact('services', 'colliveries'));
@@ -122,7 +123,7 @@ function mds_confirmed_order()
     OBJECT);
     $data = $data_[0];
 
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $collivery = $mds->returnColliveryClass();
     $directory = getcwd().'/cache/mds_collivery/waybills/'.$data->waybill;
@@ -202,7 +203,7 @@ function mds_confirmed_order_view_pdf()
         return;
     }
 
-    $mds = \MdsSupportingClasses\MdsColliveryService::getInstance();
+    $mds = MdsColliveryService::getInstance();
     $collivery = $mds->returnColliveryClass();
     $waybill_number = !empty($_GET['waybill']) ? $_GET['waybill'] : 0;
 
@@ -270,7 +271,7 @@ add_action('wp_ajax_suburbs_admin', 'suburbs_admin_callback');
 function suburbs_admin_callback()
 {
     if ((isset($_POST['town'])) && ($_POST['town'] != '')) {
-        $mds = \MdsSupportingClasses\MdsColliveryService::getInstance();
+        $mds = MdsColliveryService::getInstance();
         $collivery = $mds->returnColliveryClass();
         $fields = $collivery->getSuburbs($_POST['town']);
         if (!empty($fields)) {
@@ -329,7 +330,7 @@ add_action('wp_ajax_quote_admin', 'quote_admin_callback');
  */
 function quote_admin_callback()
 {
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $collivery = $mds->returnColliveryClass();
     $services = $collivery->getServices();
@@ -384,7 +385,7 @@ add_action('wp_ajax_accept_admin', 'accept_admin_callback');
  */
 function accept_admin_callback()
 {
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $collivery = $mds->returnColliveryClass();
     $post = $_POST;
@@ -558,7 +559,7 @@ function mds_register_collivery()
     $order = new WC_Order($_GET['post_id']);
     $order_id = $_GET['post_id'];
 
-    /** @var \MdsSupportingClasses\MdsColliveryService $mds */
+    /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
     $collivery = $mds->returnColliveryClass();
     $settings = $mds->returnPluginSettings();

--- a/script.js
+++ b/script.js
@@ -69,7 +69,7 @@ jQuery(document).ready(function () {
             return ajax = jQuery.ajax({
                 type: 'POST',
                 async: false,
-                timeout: 3000,
+                timeout: 10000,
                 url: woocommerce_params.ajax_url,
                 data: {
                     action: 'mds_collivery_generate_' + prefix,


### PR DESCRIPTION
* EP-20 : [unrelated] Replace old style arrays
  - We've supported only PHP 5.4+ for a long time
* EP-20 : [unrelated-bugfix] Try to clean up the return values of the `Collivery` class methods
  - Fixes a wide range of errors where we are processing `boolean` values as if they were `array`s
* EP-20 : [unrelated] Add the ability to override the collivery url with an env var
  - For developer convenience
* EP-20 : [unrelated] Replace old style arrays
  - We've supported only PHP 5.4+ for a long time
* EP-20 : [unrelated-bugfix] You can't wrap a `ul` in a `p`
  - use a `div` instead
* EP-20 : [unrelated-bugfix] Access the order id by the getter
  - Direct access was deprecated many versions ago, now access to the property is protected
* EP-20 : [unrelated-bugfix] Not everyone has `short_open_tags` enabled
  - It will be removed in future versions of PHP
* EP-20 : [unrelated] Import the class instead of referencing the full namespace
  - Let's not waste precious bytes
* EP-20 : [unrelated] Allow 10sec timeout just in case they're running a very slow rig
  - Or in case they're a dev with xdebug enabled ;)