### PR TITLE
Feature/ep 21/notes passed though

### DIFF
--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -363,35 +363,31 @@ class MdsColliveryService
      * @param $items
      *
      * @return bool
+     * @throws ProductOutOfException
      */
-    public function isOrderInStock($items)
-    {
-        try {
-	        $stock = 0;
-            /**  @var WC_Order_Item_Product $item */
-            foreach ($items as $item_id => $item) {
-                $qty = $item->get_quantity();
-                $product = new WC_Product($item->get_product_id());
+    public function isOrderInStock($items) {
+        $stock = 0;
+        /**  @var WC_Order_Item_Product $item */
+        foreach ($items as $item_id => $item) {
+            $qty     = $item->get_quantity();
+            $product = new WC_Product($item->get_product_id());
 
-                /** @var WC_Product|WC_Product_Variation $product */
-                if ($item->get_variation_id()) {
-                    $productVariation = new WC_Product_Variation($item->get_variation_id());
-                    if ($productVariation->get_manage_stock()) {
-                        $stock = $product->get_stock_quantity();
-                    }
-                }
-
-                if ($stock) {
-                    if ($stock < $qty) {
-                        throw new ProductOutOfException($product->get_formatted_name() . ' is out of stock', 'isOrderInStock', $this->loggerSettingsArray(), $items);
-                    }
+            /** @var WC_Product|WC_Product_Variation $product */
+            if ($item->get_variation_id()) {
+                $productVariation = new WC_Product_Variation($item->get_variation_id());
+                if ($productVariation->get_manage_stock()) {
+                    $stock = $product->get_stock_quantity();
                 }
             }
 
-            return true;
-        } catch (ProductOutOfException $e) {
-            return false;
+            if ($stock) {
+                if ($stock < $qty) {
+                    throw new ProductOutOfException($product->get_formatted_name() . ' is out of stock', 'isOrderInStock', $this->loggerSettingsArray(), $items);
+                }
+            }
         }
+
+        return true;
     }
 
     /**
@@ -423,7 +419,7 @@ class MdsColliveryService
     public function getPrice(array $array, $adjustedTotal, $markup, $fixedPrice)
     {
         if (!$result = $this->collivery->getPrice($array)) {
-            throw new InvalidColliveryDataException('Unable to get price from MDS', 'MdsColliveryService::getPrice', $this->loggerSettingsArray(), ['errors' => $this->collivery->getErrors(), 'data' => $array]);
+            throw new InvalidColliveryDataException('There was a problem sending this the delivery request to MDS Collivery, you will need to manually process. Error: Unable to get price from MDS', 'MdsColliveryService::getPrice', $this->loggerSettingsArray(), ['errors' => $this->collivery->getErrors(), 'data' => $array]);
         }
 
         $discountEnabled = $this->settings->getValue( 'method_free' ) === 'discount';
@@ -533,126 +529,214 @@ class MdsColliveryService
         return $this->collivery->validate($array);
     }
 
+    /**
+     * @param WC_Order $order
+     * @param array    $overrides
+     *
+     * @return int
+     * @throws InvalidAddressDataException
+     * @throws InvalidColliveryDataException
+     * @throws InvalidServiceException
+     * @throws OrderAlreadyProcessedException
+     * @throws ProductOutOfException
+     * @throws SoapConnectionException
+     */
+    public function orderToCollivery(WC_Order $order, array $overrides) {
+        if ($this->hasOrderBeenProcessed($order->get_id())) {
+            throw new OrderAlreadyProcessedException('Could not add MDS Collivery waybill, order already sent to MDS.', $this->loggerSettingsArray(), [
+                'order_id' => $order->get_id(),
+                'data' => $overrides,
+            ]);
+        }
+
+        if (isset($overrides['service'])) {
+            $serviceId = $overrides['service'];
+        } else {
+            foreach ($order->get_shipping_methods() as $shipping) {
+                if (preg_match('/mds_/', $shipping['method_id'])) {
+                    $serviceId = str_replace('mds_', '', $shipping['method_id']);
+                }
+            }
+        }
+
+        if (!isset($serviceId)) {
+            throw new InvalidServiceException('No MDS shipping method used', 'automatedOrderToCollivery', $this->loggerSettingsArray(), $order->get_shipping_methods());
+        }
+
+        $processing = isset($overrides['processing']) ?
+            $overrides['processing'] :
+            false;
+        $this->isOrderInStock($order->get_items());
+
+        if (isset($overrides['parcels'])) {
+            $parcels = $overrides['parcels'];
+        } else {
+            $parcels = $this->getOrderContent($order->get_items());
+        }
+
+        $defaults = $this->returnDefaultAddress();
+
+        if (!isset($overrides['which_collection_address']) && !isset($overrides['collivery_from'])) {
+            $collivery_from = $defaults['default_address_id'];
+            list($contact_from) = array_keys($defaults['contacts']);
+        } elseif (isset($overrides['which_collection_address']) && $overrides['which_collection_address'] === 'saved') {
+            $collivery_from = $overrides['collivery_from'];
+            $contact_from   = $overrides['contact_from'];
+        } else {
+            $collectionAddress = $this->addColliveryAddress([
+                'company_name'  => ($overrides['collection_company_name'] != '') ?
+                    $overrides['collection_company_name'] :
+                    'Private',
+                'building'      => $overrides['collection_building_details'],
+                'street'        => $overrides['collection_street'],
+                'location_type' => $overrides['collection_location_type'],
+                'suburb'        => $overrides['collection_suburb'],
+                'town'          => $overrides['collection_town'],
+                'full_name'     => $overrides['collection_full_name'],
+                'phone'         => preg_replace('/[^0-9]/', '', $overrides['collection_phone']),
+                'cellphone'     => preg_replace('/[^0-9]/', '', $overrides['collection_cellphone']),
+                'email'         => $overrides['collection_email'],
+            ]);
+
+            $collivery_from = $collectionAddress['address_id'];
+            $contact_from = $collectionAddress['contact_id'];
+        }
+
+        if (!isset($overrides['which_delivery_address']) && !isset($overrides['collivery_to'])) {
+            $deliveryAddress = $this->addColliveryAddress([
+                'company_name'  => ($order->get_shipping_company() != '') ? $order->get_shipping_company() : 'Private',
+                'building'      => $order->get_shipping_address_2(),
+                'street'        => $order->get_shipping_address_1(),
+                'location_type' => $order->get_meta('_shipping_location_type'),
+                'suburb'        => $order->get_meta('_shipping_suburb'),
+                'town'          => $order->get_shipping_city(),
+                'full_name'     => $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name(),
+                'cellphone'     => preg_replace('/[^0-9]/', '', $order->get_billing_phone()),
+                'email'         => str_replace(' ', '', $order->get_billing_email()),
+                'custom_id'     => $order->get_user_id(),
+            ]);
+            $collivery_to = $deliveryAddress['address_id'];
+            $contact_to   = $deliveryAddress['contact_id'];
+        } elseif (isset($overrides['which_delivery_address']) && $overrides['which_delivery_address'] === 'saved') {
+            $collivery_to = $overrides['collivery_to'];
+            $contact_to   = $overrides['contact_to'];
+        } else {
+            $deliveryAddress = $this->addColliveryAddress([
+                'company_name'  => ($overrides['delivery_company_name'] != '') ?
+                    $overrides['delivery_company_name'] :
+                    'Private',
+                'building'      => $overrides['delivery_building_details'],
+                'street'        => $overrides['delivery_street'],
+                'location_type' => $overrides['delivery_location_type'],
+                'suburb'        => $overrides['delivery_suburb'],
+                'town'          => $overrides['delivery_town'],
+                'full_name'     => $overrides['delivery_full_name'],
+                'phone'         => preg_replace('/[^0-9]/', '', $overrides['delivery_phone']),
+                'cellphone'     => preg_replace('/[^0-9]/', '', $overrides['delivery_cellphone']),
+                'email'         => $overrides['delivery_email'],
+                'custom_id'     => $order->get_user_id(),
+            ]);
+            $collivery_to = $deliveryAddress['address_id'];
+            $contact_to   = $deliveryAddress['contact_id'];
+        }
+
+
+        $instructions = isset($overrides['instructions']) ? $overrides['instructions'] : '';
+        $customReference  = '';
+        if ($this->settings->getValue('include_order_number') == 'yes') {
+            $customReference = 'Order number : ' . $order->get_id();
+            $instructions .= $customReference;
+        }
+        if ($this->settings->getValue('include_customer_note') == 'yes') {
+            if (strlen($instructions) > 0) {
+                $instructions .= '. ';
+            }
+            $instructions .= $order->get_customer_note();
+        }
+        if ($this->settings->getValue('include_product_titles') == 'yes') {
+            $count = 1;
+            if (strlen($instructions) > 0) {
+                $instructions .= ' ';
+            }
+            $instructions .= ': ';
+            foreach ($parcels as $parcel) {
+                if (isset($parcel['description'])) {
+                    $ending       = ($count == count($parcels)) ? '' : ', ';
+                    $instructions .= $parcel['quantity'] . ' X ' . $parcel['description'] . $ending;
+                    ++ $count;
+                }
+            }
+        }
+
+        $orderTotal = $this->getOrderTotal($order);
+
+        if (isset($overrides['cover'])) {
+            $riskCover = (bool) $overrides['cover'];
+        } else {
+            $riskCoverEnabled = $this->settings->getValue('risk_cover') == 'yes';
+            $overThreshold    = $orderTotal > $this->settings->getValue('risk_cover_threshold', 0);
+            $riskCover        = $riskCoverEnabled && $overThreshold;
+        }
+        $colliveryOptions = [
+            'collivery_from' => (int) $collivery_from,
+            'contact_from'   => (int) $contact_from,
+            'collivery_to'   => (int) $collivery_to,
+            'contact_to'     => (int) $contact_to,
+            'cust_ref'       => $customReference,
+            'instructions'   => $instructions,
+            'collivery_type' => 2,
+            'service'        => (int) $serviceId,
+            'cover'          => $riskCover ? 1 : 0,
+            'parcel_count'   => count($parcels),
+            'parcels'        => $parcels,
+        ];
+
+        if (isset($overrides['collection_time']) && $overrides['collection_time']) {
+            $colliveryOptions['collection_time'] = strtotime($overrides['collection_time']);
+        }
+
+        $colliveryId     = $this->addCollivery($colliveryOptions);
+
+        $collectionTime = (isset($this->validated_data['collection_time'])) ? ' anytime from: ' . date('Y-m-d H:i', $this->validated_data['collection_time']) : '';
+
+        if ($colliveryId) {
+            // Save the results from validation into our table
+            $this->addColliveryToProcessedTable($colliveryId, $order->get_id());
+            $this->updateStatusOrAddNote($order, 'Order has been sent to MDS Collivery, Waybill Number: ' . $colliveryId . ', please have order ready for collection' . $collectionTime . '.', $processing, 'completed');
+
+            return $colliveryId;
+        } else {
+            throw new InvalidColliveryDataException('Collivery did not return a waybill id', 'automatedOrderToCollivery', $this->loggerSettingsArray(), ['data' => $colliveryOptions, 'errors' => $this->collivery->getErrors()]);
+        }
+    }
+
 	/**
 	 * Auto process to send collection requests to MDS.
 	 *
 	 * @param      $order_id
 	 * @param bool $processing
 	 *
-	 * @return bool|void
+	 * @return void
 	 */
-    public function automatedAddCollivery($order_id, $processing = false)
+    public function automatedOrderToCollivery($order_id, $processing = false)
     {
         $order = new WC_Order($order_id);
 
         try {
-            if (!$this->hasOrderBeenProcessed($order->get_id())) {
-                foreach ($order->get_shipping_methods() as $shipping) {
-                    if (preg_match('/mds_/', $shipping['method_id'])) {
-                        $service_id = str_replace('mds_', '', $shipping['method_id']);
-                    }
-                }
-
-                try {
-                    if (!isset($service_id)) {
-                        throw new InvalidServiceException('No MDS shipping method used', 'automatedAddCollivery', $this->loggerSettingsArray(), $order->get_shipping_methods());
-                    }
-
-                    $this->updateStatusOrAddNote($order, 'MDS auto processing has begun.', $processing, 'processing');
-
-                    if (!$this->isOrderInStock($order->get_items())) {
-                        $this->updateStatusOrAddNote($order, 'There are products in the order that are not in stock, auto processing aborted.', $processing, 'processing');
-
-                        return false;
-                    }
-
-                    $parcels = $this->getOrderContent($order->get_items());
-                    $defaults = $this->returnDefaultAddress();
-
-                    $address = $this->addColliveryAddress([
-                        'company_name' => ($order->get_shipping_company() != '') ? $order->get_shipping_company() : 'Private',
-                        'building' => $order->get_shipping_address_2(),
-                        'street' => $order->get_shipping_address_1(),
-                        'location_type' => $order->get_meta('_shipping_location_type'),
-                        'suburb' => $order->get_meta('_shipping_suburb'),
-                        'town' => $order->get_shipping_city(),
-                        'full_name' => $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name(),
-                        'cellphone' => preg_replace('/[^0-9]/', '', $order->get_billing_phone()),
-                        'email' => str_replace(' ', '', $order->get_billing_email()),
-                        'custom_id' => $order->get_user_id(),
-                    ]);
-
-                    $collivery_from = $defaults['default_address_id'];
-                    list($contact_from) = array_keys($defaults['contacts']);
-
-                    $collivery_to = $address['address_id'];
-                    $contact_to = $address['contact_id'];
-
-                    $instructions = '';
-                    if ($this->settings->getValue('include_customer_note') == 'yes') {
-                        $instructions .= $order->get_customer_note();
-                    }
-                    if ($this->settings->getValue('include_order_number') == 'yes') {
-                        if(strlen($instructions)>0){
-                            $instructions .= ' ';
-                        }
-                        $instructions .= 'Order number: ' . $order_id;
-                    }
-                    if ($this->settings->getValue('include_product_titles') == 'yes') {
-                        $count = 1;
-                        if(strlen($instructions)>0){
-                            $instructions .= ' ';
-                        }
-                        $instructions .= ': ';
-                        foreach ($parcels as $parcel) {
-                            if (isset($parcel['description'])) {
-                                $ending = ($count == count($parcels)) ? '' : ', ';
-                                $instructions .= $parcel['quantity'] . ' X ' . $parcel['description'] . $ending;
-                                ++$count;
-                            }
-                        }
-                    }
-
-                    $orderTotal = $this->getOrderTotal($order);
-
-                    $riskCoverEnabled = $this->settings->getValue( 'risk_cover' ) == 'yes';
-                    $overThreshold = $orderTotal > $this->settings->getValue( 'risk_cover_threshold', 0 );
-                    $riskCover =  $riskCoverEnabled && $overThreshold;
-                    $colliveryOptions = [
-                        'collivery_from' => (int)$collivery_from,
-                        'contact_from' => (int)$contact_from,
-                        'collivery_to' => (int)$collivery_to,
-                        'contact_to' => (int)$contact_to,
-                        'cust_ref' => 'Order number: ' . $order_id,
-                        'instructions' => $instructions,
-                        'collivery_type' => 2,
-                        'service' => (int)$service_id,
-                        'cover' => $riskCover ? 1 : 0,
-                        'parcel_count' => count($parcels),
-                        'parcels' => $parcels,
-                    ];
-                    $collivery_id = $this->addCollivery($colliveryOptions);
-
-                    $collection_time = (isset($this->validated_data['collection_time'])) ? ' anytime from: ' . date('Y-m-d H:i', $this->validated_data['collection_time']) : '';
-
-                    if ($collivery_id) {
-                        // Save the results from validation into our table
-                        $this->addColliveryToProcessedTable($collivery_id, $order->get_id());
-                        $this->updateStatusOrAddNote($order, 'Order has been sent to MDS Collivery, Waybill Number: ' . $collivery_id . ', please have order ready for collection' . $collection_time . '.', $processing, 'completed');
-                    } else {
-                        throw new InvalidColliveryDataException('Collivery did not return a waybill id', 'automatedAddCollivery', $this->loggerSettingsArray(), ['data' => $colliveryOptions, 'errors' => $this->collivery->getErrors()]);
-                    }
-                } catch (InvalidColliveryDataException $e) {
-                    $this->updateStatusOrAddNote($order, 'There was a problem sending this the delivery request to MDS Collivery, you will need to manually process. Error: ' . $e->getMessage(), $processing, 'processing');
-                } catch (InvalidAddressDataException $e) {
-                    $this->updateStatusOrAddNote($order, 'There was a problem sending this the delivery request to MDS Collivery, you will need to manually process. Error: ' . $e->getMessage(), $processing, 'processing');
-                } catch (InvalidServiceException $e) {
-                }
-            } else {
-                $order->add_order_note('MDS Collivery automated system did not fire, order already sent to MDS.');
-            }
+            $this->updateStatusOrAddNote($order, 'MDS auto processing has begun.', $processing, 'processing');
+            $this->orderToCollivery($order, compact('processing'));
         } catch (OrderAlreadyProcessedException $e) {
-            $order->add_order_note('MDS Collivery automated system could not fire, the database table is missing which stores the processed orders.');
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
+        } catch (InvalidServiceException $e) {
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
+        } catch (ProductOutOfException $e) {
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
+        }  catch (InvalidColliveryDataException $e) {
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
+        } catch (InvalidAddressDataException $e) {
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
+        } catch (SoapConnectionException $e) {
+            $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');
         }
     }
 
@@ -688,6 +772,7 @@ class MdsColliveryService
      * @return array
      *
      * @throws InvalidAddressDataException
+     * @throws SoapConnectionException
      */
     public function addColliveryAddress(array $array)
     {
@@ -845,6 +930,7 @@ class MdsColliveryService
     {
         global $wpdb;
 
+        /** @noinspection SqlResolve */
         $result = $wpdb->get_var($wpdb->prepare("
 			SELECT COUNT(*)
 			FROM {$wpdb->prefix}mds_collivery_processed
@@ -872,6 +958,7 @@ class MdsColliveryService
     {
         global $wpdb;
 
+        /** @noinspection SqlResolve */
         return $wpdb->get_var($wpdb->prepare("SELECT meta_value FROM {$wpdb->prefix}usermeta WHERE user_id=%d AND meta_key=%s", $userId, $field));
     }
 

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -643,8 +643,9 @@ class MdsColliveryService
 
         $instructions = isset($overrides['instructions']) ? $overrides['instructions'] : '';
         $customReference  = '';
+        $orderNumberPrefix = $this->settings->getValue('order_number_prefix');
         if ($this->settings->getValue('include_order_number') == 'yes') {
-            $customReference = 'Order number : ' . $order->get_id();
+            $customReference = $orderNumberPrefix.' ' . $order->get_id();
             $instructions .= $customReference;
         }
         if ($this->settings->getValue('include_customer_note') == 'yes') {

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -48,6 +48,18 @@ class MdsFields
                 'description' => __('Includes order number which appended to the delivery instructions which max characters is 4096'),
                 'default' => 'yes',
             ],
+            'order_number_prefix' => [
+                'title' => __('Prefix for order number'),
+                'type' => 'radio',
+                'description' => __('Text before the order number'),
+                'default' => 'Order Number',
+                'options' => [
+                    '' => __('None'),
+                    '#' => __('#'),
+                    'Ord.'  => __('Ord.'),
+                    'Order Number' => __('Order Number'),
+                ],
+            ],
             'include_customer_note' => [
                 'title' => __('Include customer note'),
                 'type' => 'checkbox',

--- a/Views/_address_fields.php
+++ b/Views/_address_fields.php
@@ -28,7 +28,7 @@
             <td>
                 <select style="width: 100%;" id="<?php echo $prefix; ?>_suburb" name="<?php echo $prefix; ?>_suburb">
                     <?php foreach ($suburbs as $suburb_id => $suburb): ?>
-                        <option<?php echo isset($order) && $suburb == $order->get_meta('_shipping_suburb' ) ? ' selected="selected"' : ''; ?> value="<?php echo $suburb_id; ?>"><?php echo $suburb; ?></option>
+                        <option<?php echo isset($order) && $suburb_id == $order->get_meta('_shipping_suburb' ) ? ' selected="selected"' : ''; ?> value="<?php echo $suburb_id; ?>"><?php echo $suburb; ?></option>
                     <?php endforeach; ?>`
                 </select>
             </td>

--- a/Views/js/mds_collivery.js
+++ b/Views/js/mds_collivery.js
@@ -366,3 +366,16 @@ jQuery(function() {
 
     shippingMode.change();
 });
+
+// Order number prefix show/hide
+jQuery(function() {
+    var orderNumber = jQuery('input[name="woocommerce_mds_collivery_include_order_number"]');
+    var prefixRadios = jQuery('input[name~="woocommerce_mds_collivery_order_number_prefix"]');
+
+    orderNumber.change(function () {
+        var isOn = Boolean(orderNumber.attr('checked'));
+        isOn ? prefixRadios.hideParent('tr', false) : prefixRadios.hideParent('tr', true);
+    });
+
+    orderNumber.change();
+});

--- a/Views/js/mds_collivery.js
+++ b/Views/js/mds_collivery.js
@@ -295,42 +295,44 @@ function form_validate() {
     }
 }
 
-// remove parcel
-function remove_parcel(id) {
-    jQuery('#item' + id).remove();
-}
+(function(jQuery){
+  jQuery.fn.hideParent = function(parent, hide){
+    if(hide === true)
+      this.parents(parent).fadeOut('fast');
+    else
+      this.parents(parent).fadeIn('fast');
 
-jQuery(function(){
-    var downloadSetting = jQuery("#woocommerce_mds_collivery_downloadLogs");
-    if(downloadSetting.length > 0) {
-        var url = downloadSetting.attr('placeholder');
-        var downloadButton = document.createElement('a');
-        downloadButton.setAttribute('href', url);
-        downloadButton.setAttribute('class', 'button-primary');
-        downloadButton.innerHTML = 'Download Error Logs';
-        downloadButton.setAttribute('id', 'woocommerce_mds_collivery_downloadLogs');
-        downloadSetting.replaceWith(downloadButton);
+    return this;
+  };
 
-        var clearCacheButton = document.createElement('a');
-        clearCacheButton.innerHTML = 'Clear Cache';
-        clearCacheButton.setAttribute('class', 'button-primary');
-        clearCacheButton.setAttribute('id', 'woocommerce_mds_collivery_clearCache');
-        clearCacheButton.setAttribute('href', url.replace('mds_download_log_files', 'mds_clear_cache_files'));
-        jQuery(clearCacheButton).css('margin-right', '10px').insertBefore('#woocommerce_mds_collivery_downloadLogs');
-    }
+})(jQuery);
 
-    (function(jQuery){
-        jQuery.fn.hideParent = function(parent, hide){
-            if(hide === true)
-                this.parents(parent).fadeOut('fast');
-            else
-                this.parents(parent).fadeIn('fast');
+// Download logs / Clear Cache
+jQuery(function() {
+  var downloadSetting = jQuery("#woocommerce_mds_collivery_downloadLogs");
+  if (downloadSetting.length > 0) {
+    var url = downloadSetting.attr('placeholder');
+    var downloadButton = document.createElement('a');
+    downloadButton.setAttribute('href', url);
+    downloadButton.setAttribute('class', 'button-primary');
+    downloadButton.innerHTML = 'Download Error Logs';
+    downloadButton.setAttribute('id', 'woocommerce_mds_collivery_downloadLogs');
+    downloadSetting.replaceWith(downloadButton);
 
-            return this;
-        };
+    var clearCacheButton = document.createElement('a');
+    clearCacheButton.innerHTML = 'Clear Cache';
+    clearCacheButton.setAttribute('class', 'button-primary');
+    clearCacheButton.setAttribute('id', 'woocommerce_mds_collivery_clearCache');
+    clearCacheButton.setAttribute('href',
+        url.replace('mds_download_log_files', 'mds_clear_cache_files'));
+    jQuery(clearCacheButton)
+        .css('margin-right', '10px')
+        .insertBefore('#woocommerce_mds_collivery_downloadLogs');
+  }
+})
 
-    })(jQuery);
-
+// Shipping mode show/hide
+jQuery(function() {
     var shippingMode = jQuery('select[name="woocommerce_mds_collivery_method_free"]');
     var percentageDiscount = jQuery('input[name="woocommerce_mds_collivery_shipping_discount_percentage"]');
     var freeDeliveryBlacklist = jQuery('input[name="woocommerce_mds_collivery_free_delivery_blacklist"]');

--- a/Views/order.php
+++ b/Views/order.php
@@ -32,7 +32,6 @@ use MdsSupportingClasses\View;
                         'contacts' => ['' => 'Select Contact'] + $defaults['contacts'],
                         'addresses' => ['' => 'Select Address'] + $addresses,
                         'default_address_id' => $defaults['default_address_id'],
-                        'order' => $order,
                     ]); ?>
                 </td>
                 <td style="min-width:20%; max-width:40%; vertical-align: top; padding: 0 10px;">

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -107,6 +107,65 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
         $this->init_instance_settings();
     }
 
+    public function generate_radio_html($name, array $options) {
+        $fieldName = esc_attr($this->get_field_key($name));
+        $defaults  = [
+            'title'             => '',
+            'label'             => '',
+            'disabled'          => false,
+            'class'             => '',
+            'css'               => '',
+            'type'              => 'radio',
+            'desc_tip'          => false,
+            'description'       => '',
+            'default'           => false,
+            'custom_attributes' => [],
+            'options'           => [],
+        ];
+
+        $options = wp_parse_args($options, $defaults);
+
+        if (!$options['label']) {
+            $options['label'] = $options['title'];
+        }
+
+        ob_start();
+        ?>
+        <tr valign="top">
+            <th scope="row" class="titledesc">
+                <label for="<?php echo $fieldName; ?>">
+                    <?php echo wp_kses_post($options['title']); ?><?php echo $this->get_tooltip_html($options); ?>
+                </label>
+            </th>
+            <td class="forminp">
+                <fieldset>
+                    <legend class="screen-reader-text"><span><?php echo wp_kses_post($options['title']); ?></span></legend>
+                        <?php foreach ($options['options'] as $key => $text): ?>
+                        <?php $uniqid = $fieldName.'_'.esc_attr($key); ?>
+                            <label for="<?php echo $uniqid; ?>">
+                                <input
+                                    <?php disabled($options['disabled'], true); ?>
+                                    class="<?php echo esc_attr($options['class']); ?>"
+                                    type="radio"
+                                    name="<?php echo $fieldName; ?>"
+                                    id="<?php echo $uniqid; ?>"
+                                    style="<?php echo esc_attr($options['css']); ?>"
+                                    value="<?php echo esc_attr($key); ?>"
+                                    <?php checked($this->get_option($name), $key); ?>
+                                    <?php echo $this->get_custom_attribute_html($options);?> />
+
+                                <?php echo esc_attr($text); ?>
+                          </label> <br>
+                        <?php endforeach; ?>
+                    <?php echo $this->get_description_html($options); ?>
+                </fieldset>
+            </td>
+        </tr>
+        <?php
+
+        return ob_get_clean();
+    }
+
     /**
      * Function used by Woocommerce to fetch shipping price.
      *

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.6.0');
+define('MDS_VERSION', '3.7.0');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,7 +11,7 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.6.0
+ * Version: 3.7.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/collivery.php
+++ b/collivery.php
@@ -194,11 +194,11 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          *
          * @param $order_id
          *
-         * @return string
+         * @return void
          */
         function automated_add_collivery_payment_complete($order_id)
         {
-	        return MdsColliveryService::getInstance()->automatedAddCollivery($order_id);
+	        MdsColliveryService::getInstance()->automatedOrderToCollivery($order_id);
         }
 
             if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
@@ -212,11 +212,11 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
          *
          * @param $order_id
          *
-         * @return bool|null
+         * @return void
          */
         function automated_add_collivery_status_processing($order_id)
         {
-	        return MdsColliveryService::getInstance()->automatedAddCollivery($order_id, true);
+	        MdsColliveryService::getInstance()->automatedOrderToCollivery($order_id, true);
         }
 
         if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -446,7 +446,7 @@ function mds_enqueue_admin_js()
 {
     wp_register_script('jquery.datetimepicker.min_js', plugin_dir_url(__FILE__).'/Views/js/jquery.datetimepicker.min.js');
     wp_enqueue_script('jquery.datetimepicker.min_js');
-    wp_register_script('mds_collivery_js', plugin_dir_url(__FILE__).'/Views/js/mds_collivery.js');
+    wp_register_script('mds_collivery_js', plugin_dir_url(__FILE__).'/Views/js/mds_collivery.js', ['jquery'], MDS_VERSION);
     wp_enqueue_script('mds_collivery_js');
     wp_register_script('jquery.validate.min_js', plugin_dir_url(__FILE__).'/Views/js/jquery.validate.min.js');
     wp_enqueue_script('jquery.validate.min_js');

--- a/mds_admin.php
+++ b/mds_admin.php
@@ -387,121 +387,27 @@ function accept_admin_callback()
 {
     /** @var MdsColliveryService $mds */
     $mds = MdsColliveryService::getInstance();
-    $collivery = $mds->returnColliveryClass();
-    $post = $_POST;
+    $overrides = $_POST;
+    $order = new WC_Order($overrides['order_id']);
 
     try {
-        $order = new WC_Order($post['order_id']);
-        if (!$mds->hasOrderBeenProcessed($order->get_id())) {
-            // Check which collection address we using and if we need to add the address to collivery api
-            if ($post['which_collection_address'] == 'default') {
-                $collection_address = $mds->addColliveryAddress([
-                    'company_name' => ($post['collection_company_name'] != '') ? $post['collection_company_name'] : 'Private',
-                    'building' => $post['collection_building_details'],
-                    'street' => $post['collection_street'],
-                    'location_type' => $post['collection_location_type'],
-                    'suburb' => $post['collection_suburb'],
-                    'town' => $post['collection_town'],
-                    'full_name' => $post['collection_full_name'],
-                    'phone' => preg_replace('/[^0-9]/', '', $post['collection_phone']),
-                    'cellphone' => preg_replace('/[^0-9]/', '', $post['collection_cellphone']),
-                    'email' => $post['collection_email'],
-                ]);
+        $colliveryId = $mds->orderToCollivery($order, $overrides);
+        $validatedData = $mds->returnColliveryValidatedData();
+        $collection_time = (isset($validatedData['collection_time']))
+            ? ' anytime from: ' . date('Y-m-d H:i', $validatedData['collection_time'])
+            : '';
 
-                // Check for any problems
-                if ($collivery->hasErrors()) {
-                    wp_send_json([
-                        'redirect' => false,
-                        'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                    ]);
-                } else {
-                    // set the collection address and contact from the returned array
-                    $collivery_from = $collection_address['address_id'];
-                    $contact_from = $collection_address['contact_id'];
-                }
-            } else {
-                $collivery_from = $post['collivery_from'];
-                $contact_from = $post['contact_from'];
-            }
+        $message = "Order has been sent to MDS Collivery, Waybill Number: {$colliveryId}, please have order ready for collection{$collection_time}.";
 
-            // Check which delivery address we using and if we need to add the address to collivery api
-            if ($post['which_delivery_address'] == 'default') {
-                $delivery_address = $mds->addColliveryAddress([
-                    'company_name' => ($post['delivery_company_name'] != '') ? $post['delivery_company_name'] : 'Private',
-                    'building' => $post['delivery_building_details'],
-                    'street' => $post['delivery_street'],
-                    'location_type' => $post['delivery_location_type'],
-                    'suburb' => $post['delivery_suburb'],
-                    'town' => $post['delivery_town'],
-                    'full_name' => $post['delivery_full_name'],
-                    'phone' => preg_replace('/[^0-9]/', '', $post['delivery_phone']),
-                    'cellphone' => preg_replace('/[^0-9]/', '', $post['delivery_cellphone']),
-                    'email' => $post['delivery_email'],
-                    'custom_id' => $order->get_user_id(),
-                ]);
-
-                // Check for any problems
-                if ($collivery->hasErrors()) {
-                    wp_send_json([
-                        'redirect' => false,
-                        'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                    ]);
-                } else {
-                    $collivery_to = $delivery_address['address_id'];
-                    $contact_to = $delivery_address['contact_id'];
-                }
-            } else {
-                $collivery_to = $post['collivery_to'];
-                $contact_to = $post['contact_to'];
-            }
-
-            $collivery_id = $mds->addCollivery([
-                'collivery_from' => $collivery_from,
-                'contact_from' => $contact_from,
-                'collivery_to' => $collivery_to,
-                'contact_to' => $contact_to,
-                'cust_ref' => 'Order number: '.$order->get_id(),
-                'instructions' => $post['instructions']." ".$order->get_customer_note(),
-                'collivery_type' => 2, // Package
-                'service' => $post['service'],
-                'cover' => $post['cover'],
-                'collection_time' => strtotime($post['collection_time']),
-                'parcel_count' => count($post['parcels']),
-                'parcels' => $post['parcels'],
-            ]);
-
-            // Check for any problems validating
-            if (!$collivery_id) {
-                $mds->updateStatusOrAddNote($order, 'There was a problem sending this the delivery request to MDS Collivery, you will need to manually process.', true, 'processing');
-
-                wp_send_json([
-                    'redirect' => false,
-                    'message' => '<p class="mds_response">'.implode(', ', $collivery->getErrors()).'</p>',
-                ]);
-            } else {
-                $validatedData = $mds->returnColliveryValidatedData();
-                $collection_time = (isset($validatedData['collection_time'])) ? ' anytime from: '.date('Y-m-d H:i', $validatedData['collection_time']) : '';
-
-                // Save the results from validation into our table
-                $mds->addColliveryToProcessedTable($collivery_id, $order->get_id());
-                $message = 'Order has been sent to MDS Collivery, Waybill Number: '.$collivery_id.', please have order ready for collection'.$collection_time.'.';
-                $mds->updateStatusOrAddNote($order, $message, false, 'completed');
-
-                wp_send_json([
-                    'redirect' => true,
-                    'message' => '<p class="mds_response">'.$message.' You will be redirect to your order in 5 seconds.</p>',
-                ]);
-            }
-        } else {
-            wp_send_json([
-                'redirect' => false,
-                'message' => '<p class="mds_response">Sorry, this order has already been processed.</p>',
-            ]);
-        }
-    } catch (Exception $e) {
+        wp_send_json([
+            'redirect' => true,
+            'message'  => '<p class="mds_response">' . $message . ' You will be redirect to your order in 5 seconds.</p>',
+        ]);
+    } catch (\Exception $e) {
+        $mds->updateStatusOrAddNote($order, $e->getMessage(), true, 'processing');
         wp_send_json([
             'redirect' => false,
-            'message' => '<p class="mds_response">'.$e->getMessage().'</p>',
+            'message'  => '<p class="mds_response">' . $e->getMessage() . '</p>',
         ]);
     }
 }


### PR DESCRIPTION
* EP-21 : [change] Minor clean up to MDS admin JS
* EP-21 : [change] Refactor adding waybills to use only one piece of code
  - Code was duplicated and slightly divergent between manual add automated methods
    * the divergence was not purposeful, but errors frm having two pieces to maintain
  - Both methods now proxy through to `MdsColliveryService::orderToCollivery`
  - Let all exceptions bubble up to the "controller" methods handling them to turn into error messages
* EP-21 : [create] Add the ability to select an "order number prefix"
  - Default is what we hard-coded previously
  - Add method to render a radio
    * allow for a collection of options
  - Add js to show and hide the "order number prefix" selection depending on "show order number"
* EP-21 : [change] Implement dynamically getting the order number from the settings
* EP-21 : [bugfix] Ensure the suburb is auto-selected for the delivery address
  - compare the `id ~> id` not `name ~> id`
* EP-21 : [bugfix] Do not pass the `order` through to the collection address view
  - We don't want it pre-populated with the delivery address details
* EP-21 : [change] Version the admin JS in order to be able to bust caches
* EP-21 : [change] Bump version numbers
  - Functionality is affected enough to go for minor version not just a patch