### PR TITLE
Bugfix/checkout/town

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.7.1');
+define('MDS_VERSION', '3.7.2');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,7 +11,7 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.7.1
+ * Version: 3.7.2
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5

--- a/mds_checkout_fields.php
+++ b/mds_checkout_fields.php
@@ -89,8 +89,10 @@ if ($mds->isEnabled()) {
 					'WC'  => 'CAP',
 				];
 				$province    = isset( $provinceMap[ $_POST['parentValue'] ] ) ? $provinceMap[ $_POST['parentValue'] ] : 'unknown';
-				wp_send_json( View::make( '_options', [
-					'fields'        => $collivery->getTowns( 'ZAF', $province ),
+                $towns      = $collivery->getTowns('ZAF', $province);
+                $towns       = array_combine($towns, $towns);
+                wp_send_json( View::make( '_options', [
+					'fields'        => $towns,
 					'placeholder'   => 'Select town/city',
 					'selectedValue' => $selectedTown,
 				] ) );

--- a/mds_checkout_fields.php
+++ b/mds_checkout_fields.php
@@ -123,7 +123,9 @@ if ($mds->isEnabled()) {
 
 			if ( ( isset( $_POST['parentValue'] ) ) && ( $_POST['parentValue'] != '' ) ) {
 				$collivery = $mds->returnColliveryClass();
-				$town_id   = array_search( $_POST['parentValue'], $collivery->getTowns() );
+				$town_id   = is_numeric($_POST['parentValue']) ?
+                    $_POST['parentValue'] :
+                    array_search( $_POST['parentValue'], $collivery->getTowns() );
 				$fields    = $collivery->getSuburbs( $town_id );
 
 				if ( ! empty( $fields ) ) {

--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ jQuery(document).ready(function () {
             cacheValue(fromField, fromEl.val());
             return ajax = jQuery.ajax({
                 type: 'POST',
-                async: false,
+                async: true,
                 timeout: 10000,
                 url: woocommerce_params.ajax_url,
                 data: {


### PR DESCRIPTION
* [change] Bump version number
* [change] Allow our request that fetches the town/suburb to be asynchronous 
  - For speed
* [change] Better handle erroneous data for Town Ids 
  - in the case of (previously buggy code) it could be either a string or an int
* [bugfix] Ensure that the `postmeta._billing_city` is always a string 
  - Previously different code paths gave different results for the "Town" dropdown
     * Some had string values, some had int values