### PR TITLE
Improvement/error reporting and logging

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -1059,7 +1059,7 @@ class Collivery
             } catch (SoapFault $e) {
                 $this->catchSoapFault($e);
 
-                return false;
+                return [];
             }
 
             if (is_array($result)) {
@@ -1075,7 +1075,7 @@ class Collivery
                     $this->setError('result_unexpected', 'No result returned.');
                 }
 
-                return false;
+                return [];
             }
         }
     }

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -707,7 +707,8 @@ class MdsColliveryService
 
             return $colliveryId;
         } else {
-            throw new InvalidColliveryDataException('Collivery did not return a waybill id', 'automatedOrderToCollivery', $this->loggerSettingsArray(), ['data' => $colliveryOptions, 'errors' => $this->collivery->getErrors()]);
+            $errors = $this->collivery->getErrors();
+            throw new InvalidColliveryDataException('Error sending to Collivery: ' . implode(', ', $errors), 'automatedOrderToCollivery', $this->loggerSettingsArray(), ['data' => $colliveryOptions, 'errors' => $errors]);
         }
     }
 

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -452,7 +452,7 @@ class MdsColliveryService
     {
         $this->validated_data = $validatedData = $this->validateCollivery($array);
 
-	    if (is_null($validatedData)) {
+	    if (empty($validatedData)) {
 		    return false;
 	    }
 

--- a/MdsSupportingClasses/MdsLogger.php
+++ b/MdsSupportingClasses/MdsLogger.php
@@ -175,7 +175,7 @@ class MdsLogger
             }
         }
 
-        if (file_put_contents($this->getLogDirectory().$name, json_encode([time() => $value], JSON_PRETTY_PRINT), FILE_APPEND)) {
+        if (file_put_contents($this->getLogDirectory().$name, json_encode([date('Y-m-d H:i:s') => $value], JSON_PRETTY_PRINT), FILE_APPEND)) {
             return true;
         } else {
             return false;

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '3.7.2');
+define('MDS_VERSION', '3.7.3');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,7 +11,7 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 3.7.2
+ * Version: 3.7.3
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5


### PR DESCRIPTION
* 6c6f6ed [change] Bump version number [change] Bump version number
* a52e735 [change] Use a human-readable date/time format. 
  - Helps us when debugging without needing to convert it
* 87ac790 [bugfix] Show the user the error returned from the SOAP API 
  - It's useful
* ecad7fc [bugfix] Correctly assert the return type from `Collivery::validate()` 
  - `Collivery::validate()` returned `false` or `array` 
  - Now it only returns an array 
  - There are other parts of the plugin that operate as if it has an array not a boolean
* c21a45a [bugfix] Return consistent result types from `Collivery::validate()` 
  - There are other parts of the plugin that operate as if it has an array not a boolean