### PR TITLE
Bug/variable product bug

### DIFF
--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -297,7 +297,7 @@ class MdsColliveryService
             foreach ($cart as $item) {
                 $product = $item['data'];
 
-                $package['contents'][$item['product_id']] = [
+                $package['contents'][$product->get_id()] = [
                     'data' => $item['data'],
                     'quantity' => $item['quantity'],
                     'price' => $product->get_price(),

--- a/collivery.php
+++ b/collivery.php
@@ -15,7 +15,7 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5
- * WC tested up to: 4.5.4
+ * WC tested up to: 4.5.2
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '4.0.0');
+define('MDS_VERSION', '4.0.1');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,11 +11,11 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 4.0.0
+ * Version: 4.0.1
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 3.5
- * WC tested up to: 4.5.2
+ * WC tested up to: 4.5.4
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');


### PR DESCRIPTION
Updated code to get the id from the $product class. The get_id() function either returns the variation_id or the product_id, depending on whether variation_id is available or not.

Updated versioning to 4.0.1 and created the tag (4.0.1)