### PR TITLE
Bugfix/service type/onx before 10

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -295,7 +295,7 @@ class Collivery
                 return [];
             }
 
-            if (isset($result)) {
+            if (isset($result['data'])) {
                 if ($this->check_cache) {
                     $this->cache->put('collivery.search_towns.'.$name, $result['data'], 60 * 24);
                 }
@@ -605,7 +605,7 @@ class Collivery
                     $this->cache->put('collivery.parcel_image_list.'.$this->client_id.'.'.$collivery_id, $result['images'], 60 * 12);
                 }
 
-                return $result['images'];
+                return $result['data'];
             } else {
                 return $this->checkError($result);
             }
@@ -637,14 +637,12 @@ class Collivery
                 return false;
             }
 
-            if (isset($result['image'])) {
-                if (isset($result['error'])) {
-                    $this->setError($result['error']['http_code'], $result['error']['message']);
-                } elseif ($this->check_cache) {
-                    $this->cache->put('collivery.parcel_image.'.$this->client_id.'.'.$parcel_id, $result['image'], 60 * 24);
+            if (isset($result['data'])) {
+                if ($this->check_cache) {
+                    $this->cache->put('collivery.parcel_image.'.$this->client_id.'.'.$parcel_id, $result['data'], 60 * 24);
                 }
 
-                return $result['image'];
+                return $result['data'];
             } else {
                 return $this->checkError($result);
             }
@@ -789,7 +787,7 @@ class Collivery
                 return false;
             }
 
-            if (isset($result['contact_id'])) {
+            if (isset($result['data'])) {
                 return $result;
             } else {
                 return $this->checkError($result);
@@ -841,10 +839,7 @@ class Collivery
             return false;
         }
 
-        if (is_array($result)) {
-            if (isset($result['error'])) {
-                $this->setError($result['error']['http_code'], $result['error']['message']);
-            }
+        if (isset($result['data'])) {
             return $result;
         } else {
             return $this->checkError($result);

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -85,13 +85,14 @@ class Collivery
 
     /**
      * Consumes API
-     * 
-     * @param string $url The URL you're accessing
-     * @param array $data The params or query the URL requires.
-     * @param string $type ~ Defines how the data is sent (POST / GET)
-     * @param bool $isAuthenticating Whether the API requires the api_token
-     * 
+     *
+     * @param  string  $url               The URL you're accessing
+     * @param  array   $data              The params or query the URL requires.
+     * @param  string  $type              ~ Defines how the data is sent (POST / GET)
+     * @param  bool    $isAuthenticating  Whether the API requires the api_token
+     *
      * @return array $result
+     * @throws CurlConnectionException
      */
     private function consumeAPI($url, $data, $type, $isAuthenticating = false) {
         if (!$isAuthenticating) {
@@ -120,7 +121,8 @@ class Collivery
             'X-App-Version:'.$this->config->app_version,
             'X-App-Host:'.$this->config->app_host,
             'X-App-Lang:'.'PHP '.phpversion(),
-            'Content-Type: application/json'];
+            'Content-Type: application/json'
+        ];
 
         curl_setopt($client, CURLOPT_HTTPHEADER, $headerArray);
 
@@ -149,19 +151,14 @@ class Collivery
             ]);
         }
 
-            curl_close($client);
+        curl_close($client);
 
-            // If $result is already an array.
-            if (is_array($result)) {
-                return $result;
-            }
-
-            return json_decode($result, true);
-        } catch (CurlConnectionException $e) {
-            $this->catchException($e);
+        // If $result is already an array.
+        if (is_array($result)) {
+            return $result;
         }
 
-        return [];
+        return json_decode($result, true);
     }
 
     /**
@@ -670,7 +667,7 @@ class Collivery
     public function getStatus($collivery_id)
     {
         try {
-            $result = $this->consumeAPI("https://api.collivery.co.za/v3/status_tracking/".$collivery_id, ["api_token" => ""], 'GET');
+            $result = $this->consumeAPI("https://api.collivery.co.za/v3/status_tracking/".$collivery_id, [], 'GET');
         } catch (CurlConnectionException $e) {
             $this->catchException($e);
 
@@ -898,9 +895,6 @@ class Collivery
         }
 
         if (!$this->hasErrors()) {
-
-            $newObject = [];
-
             $newObject = [
                 "service" => $data["service"],
                 "parcels" => $data["parcels"],

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -459,7 +459,7 @@ class MdsColliveryService
     {
         $this->validated_data = $validatedData = $this->validateCollivery($array);
 
-	    if (empty($validatedData)) {
+	    if (empty($validatedData) || is_bool($validatedData)) {
 		    return false;
 	    }
 
@@ -548,10 +548,8 @@ class MdsColliveryService
      * @throws ProductOutOfException
      * @throws CurlConnectionException
      */
-    public function orderToCollivery(WC_Order $order, array $overrides) {
-
-        
-
+    public function orderToCollivery(WC_Order $order, array $overrides)
+    {
         if ($this->hasOrderBeenProcessed($order->get_id())) {
             throw new OrderAlreadyProcessedException('Could not add MDS Collivery waybill, order already sent to MDS.', $this->loggerSettingsArray(), [
                 'order_id' => $order->get_id(),
@@ -573,17 +571,9 @@ class MdsColliveryService
             throw new InvalidServiceException('No MDS shipping method used', 'automatedOrderToCollivery', $this->loggerSettingsArray(), $order->get_shipping_methods());
         }
 
-        $processing = isset($overrides['processing']) ?
-            $overrides['processing'] :
-            false;
+        $processing = $overrides['processing'] ?? false;
         $this->isOrderInStock($order->get_items());
-
-        if (isset($overrides['parcels'])) {
-            $parcels = $overrides['parcels'];
-        } else {
-            $parcels = $this->getOrderContent($order->get_items());
-        }
-
+        $parcels = $overrides['parcels'] ?? $this->getOrderContent($order->get_items());
         $defaults = $this->returnDefaultAddress();
 
         if (!isset($overrides['which_collection_address']) && !isset($overrides['collivery_from'])) {
@@ -668,7 +658,7 @@ class MdsColliveryService
         }
 
 
-        $instructions = isset($overrides['instructions']) ? $overrides['instructions'] : '';
+        $instructions = $overrides['instructions'] ?? '';
         $customReference  = '';
         $orderNumberPrefix = $this->settings->getValue('order_number_prefix');
         if ($this->settings->getValue('include_order_number') == 'yes') {
@@ -738,13 +728,12 @@ class MdsColliveryService
             }
         }
 
-        $collivery     = $this->addCollivery($colliveryOptions);
+        $collivery = $this->addCollivery($colliveryOptions);
 
-        $collectionTime = (isset($collivery['data']['collection_time'])) ? ' anytime from: ' . date('Y-m-d H:i', $collivery['data']['collection_time']) : '';
         if ($collivery['data']['id']) {
             // Save the results from validation into our table
             $this->addColliveryToProcessedTable($collivery, $order->get_id());
-            $this->updateStatusOrAddNote($order, 'Order has been sent to MDS Collivery, Waybill Number: ' . $collivery['data']['id'] . ', please have order ready for collection' . $collectionTime . '.', $processing, 'completed');
+            $this->updateStatusOrAddNote($order, 'Order has been sent to MDS Collivery, Waybill Number: ' . $collivery['data']['id'] . ', please have order ready for collection any time from ' . date('Y-m-d H:i', $collivery['data']['collection_time']) . '.', $processing, 'completed');
 
             return $collivery;
         } else {

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -722,11 +722,20 @@ class MdsColliveryService
         if (isset($overrides['collection_time']) && $overrides['collection_time']) {
             $colliveryOptions['collection_time'] = $overrides['collection_time'];
         } else {
-            $collection_time = date("Y-m-d H:i:s", strtotime(date("Y-m-d").' + 1 days + 12 hours'));
-            while(date('N', strtotime($collection_time)) >= 6) {
-                $collection_time = date("Y-m-d H:i:s", strtotime($collection_time.' + 1 days'));
+            $collectionTime = date('Y-m-d H:i:s', strtotime(date('Y-m-d').' + 1 days + 12 hours'));
+            // Ensure it's a week day
+            while(date('N', strtotime($collectionTime)) >= 6) {
+                $collectionTime = date('Y-m-d H:i:s', strtotime($collectionTime.' + 1 days'));
             }
-            $colliveryOptions['collection_time'] = $collection_time;
+            $colliveryOptions['collection_time'] = $collectionTime;
+        }
+
+        if ($serviceId == Collivery::ONX_10) {
+            $deliveryTime =  date('Y-m-d H:i:s', strtotime(date('Y-m-d', strtotime($colliveryOptions['collection_time'])).' 10:00:00 + 2 days'));
+            // Ensure it's a week day
+            while(date('N', strtotime($deliveryTime)) >= 6) {
+                $deliveryTime = date('Y-m-d H:i:s', strtotime($deliveryTime.' + 1 days'));
+            }
         }
 
         $collivery     = $this->addCollivery($colliveryOptions);

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -269,7 +269,10 @@ class MdsFields
     {
         $cache = $service->returnCacheClass();
         if ($cache->has('resources')) {
-            return $cache->get('resources');
+            $resources = $cache->get('resources');
+            $resources['services'] = $service->returnColliveryClass()->filterServices($resources['services']);
+
+            return $resources;
         }
 
         $collivery = $service->returnColliveryClass();

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -248,7 +248,9 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                         }
                     }
                 } catch (CurlConnectionException $e) {
+                    (new MdsLogger())->error('WC_Mds_Shipping_Method::calculate_shipping()', $e->getMessage(), $this->collivery_service->loggerSettingsArray(), $package);
                 } catch (InvalidColliveryDataException $e) {
+                  (new MdsLogger())->error('WC_Mds_Shipping_Method::calculate_shipping()', $e->getMessage(), $this->collivery_service->loggerSettingsArray(), $package);
                 }
             }
         }

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -4,11 +4,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+use MdsExceptions\CurlConnectionException;
 use MdsExceptions\InvalidColliveryDataException;
 use MdsExceptions\InvalidResourceDataException;
-use MdsExceptions\CurlConnectionException;
+use MdsSupportingClasses\Collivery;
 use MdsSupportingClasses\MdsColliveryService;
 use MdsSupportingClasses\MdsFields;
+use MdsSupportingClasses\MdsLogger;
 use MdsSupportingClasses\MdsSettings;
 
 /**
@@ -183,11 +185,11 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                     $id = 'mds_'.$this->mdsSettings->getInstanceValue('free_default_service');
                 }
 
-	            $this->id = $id;
+                $this->id = $id;
                 $this->add_rate([
-                    'id' => $id,
+                    'id'    => $id,
                     'label' => $this->mdsSettings->getInstanceValue('wording_free', 'Free Delivery'),
-                    'cost' => 0.0,
+                    'cost'  => 0.0,
                 ]);
             } elseif (!isset($package['service']) || (isset($package['service']) && $package['service'] != 'free')) {
                 try {
@@ -195,7 +197,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                     if (is_array($services)) {
                         // Get pricing for each service
                         foreach ($services as $service) {
-                            if ($this->mdsSettings->getInstanceValue("method_".$service['id']) == 'yes') {
+                            if ($this->mdsSettings->getInstanceValue('method_'.$service['id']) === 'yes') {
                                 // Now lets get the price for
                                 $riskCover = false;
                                 $adjustedTotal = $package['shipping_cart_total'];
@@ -229,7 +231,7 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                 if (in_array($service['id'], [Collivery::ONX, Collivery::ONX_10])) {
                                   $service['text'] .= ', additional 24 hours on outlying areas';
                                 } else {
-                                    $service['text'] = $this->mdsSettings->getInstanceValue("wording_".$service['id']);
+                                    $service['text'] = $this->mdsSettings->getInstanceValue('wording_'.$service['id']);
                                 }
 
                                 $label = $service['text'];

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -215,12 +215,19 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     'exclude_weekend' => true,
                                     'services' => [$service['id']],
                                 ];
-                                
+
+                                // Add the requested time to ONX before 10
+                                if ($service['id'] === Collivery::ONX_10) {
+                                    $data['delivery_time'] = '10:00 next monday';
+                                    $data['services'] = [Collivery::ONX];
+                                }
+
+
                                 // Looks like it's being executed here;
                                 $price = $this->collivery_service->getPrice($data, $adjustedTotal, $this->mdsSettings->getInstanceValue( 'markup_' . $service['id']), $this->mdsSettings->getInstanceValue( 'fixed_price_' . $service['id']));
-                                
-                                if ($this->mdsSettings->getInstanceValue("wording_".$service['id'], $service['text']) == $service['text'] && ($service['id'] == 1 || $service['id'] == 2)) {
-                                    $service['text'] = $service['text'].', additional 24 hours on outlying areas';
+
+                                if (in_array($service['id'], [Collivery::ONX, Collivery::ONX_10])) {
+                                  $service['text'] .= ', additional 24 hours on outlying areas';
                                 } else {
                                     $service['text'] = $this->mdsSettings->getInstanceValue("wording_".$service['id']);
                                 }

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '4.0.1');
+define('MDS_VERSION', '4.0.2');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,11 +11,11 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 4.0.1
+ * Version: 4.0.2
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
- * WC requires at least: 3.5
- * WC tested up to: 4.5.2
+ * WC requires at least: 4.0
+ * WC tested up to: 4.8
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');

--- a/collivery.php
+++ b/collivery.php
@@ -34,7 +34,7 @@ if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_
                 wp_die('Sorry, but you cannot run this plugin, it requires the <a href="http://php.net/manual/en/class.soapclient.php">SOAP</a> support on your server/hosting to function.');
             }
 
-            if (!version_compare(phpversion(), '5.4.0', '>=')) {
+            if (!version_compare(phpversion(), '7.0.0', '>=')) {
                 deactivate_plugins(basename(__FILE__));
                 wp_die('Sorry, but you cannot run this plugin, it requires PHP version 5.4 or higher');
             }


### PR DESCRIPTION
* 3183fe1 [bugfix] Re-implement `ONX Before 10:00`
  - The REST API doesn't send through customised services, just the standard ones
  - Manually create a `ONX_10` service
  - Ensure that cached services data and the data from the API are filtered
    * Remove the `SDX` service
    * Create the `ONX_10` service
  - Change the data we send to `quote` and `waybill.store` endpoints to include `delivery_time` if service == `ONX_10`
  - Add constants for service ids in order to avoid constantly dealing with magic numbers throughout the code
* 4b17c94 [bugfix] Deal with response data that would never exist in the response
  - All status 20X responses from the rest api have a `data` key
* d94ac52 [bugfix] Improved error handling
  - Log an error even if there's not an explicit exception thrown by curl
  - Remove the extra checks for `$response['error']` as those are handled higher up the execution chain
  - Do not catch an exception within 10 lines of throwing it
    * Catching and logging is handled later in the execution
  - Ensure we actually log the errors we catch
* d88efd7 [change] Various clean ups
  - Some minor PSR 1 and PSR2 improvements
    * Cleaning everything would drown the actual changes in clean-ups
  - Annotate thrown exceptions for better IDE suggestions
  - Remove some completely redundant code
  - Replace some uses of `isset()` with null coalescence
* 0688763 [change] Update versioning
  - Update to 4.0.2
  - Update compatibility for "up to" to latest WC
  - Update compatibility for "at least" to current major version of WC
    * I have no faith that this would still work on 3.5
* d1f498b [change] Update php versioning
  - The current WC version requires at least 7.0.0
  - We use PHP 7.0 features in the codebase