### PR TITLE
Hotfix/postal code/required

### DIFF
--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -204,11 +204,13 @@ class MdsCheckoutFields
                     'class' => ['form-row-wide'],
                 ],
                 $prefix.'postcode' => [
-                    'priority' => 15,
-                    'label' => 'Postal Code',
-                    'placeholder' => 'Postal Code',
-                    'required' => false,
-                    'class' => ['form-row-wide', 'address-field', 'update_totals_on_change'],
+                    'priority'     => 15,
+                    'label'        => 'Postal Code',
+                    'placeholder'  => 'Postal Code',
+                    'required'     => true,
+                    'class'        => ['form-row-wide', 'address-field', 'update_totals_on_change'],
+                    'validate'     => ['postcode'],
+                    'autocomplete' => 'postal-code',
                 ],
             ];
         } catch (InvalidResourceDataException $e) {

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '4.1.2');
+define('MDS_VERSION', '4.1.3');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 
@@ -11,11 +11,11 @@ require_once ABSPATH.'wp-includes/functions.php';
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 4.1.2
+ * Version: 4.1.3
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 4.0
- * WC tested up to: 4.8
+ * WC tested up to: 5.0.0
  */
 if (in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins')))) {
     register_activation_hook(__FILE__, 'activate_mds');


### PR DESCRIPTION
- [bugfix] Do not override `postcode.required` 
  * It's `required => true` in woocommerce default 
  * Add the `validate` and `autocomplete` from the default woocommerce field
- [change] Bump version number 
  * Bump max WooCommerce version