### PR TITLE
Bugfix/custom fields

### DIFF
--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -50,20 +50,17 @@ class MdsCheckoutFields
     public function getCheckoutFields($prefix = null)
     {
         $service = MdsColliveryService::getInstance();
+        $defaultFields = $this->defaultFields[$prefix] ?? $this->defaultFields;
 
         if (!$service->isEnabled()) {
-            if (isset($this->defaultFields[$prefix])) {
-                return $this->defaultFields[$prefix];
-            } else {
-                return $this->defaultFields;
-            }
+            return $defaultFields;
         }
 
         try {
             $resources = MdsFields::getResources($service);
 
             if ($prefix) {
-                $prefix = $prefix.'_';
+                $prefix .= '_';
             }
 
             $towns = $this->make_key_value_array($resources['towns'], 'name', 'name');
@@ -72,7 +69,7 @@ class MdsCheckoutFields
             $towns = ['' => 'Select Town'] + $towns;
             $location_types = ['' => 'Select Premises Type'] + $location_types;
 	        $customer = WC()->customer;
-	        $cityPrefix = $prefix ? $prefix : 'billing_';
+	        $cityPrefix = $prefix ?: 'billing_';
             
             $townName = '';
 

--- a/MdsSupportingClasses/MdsCheckoutFields.php
+++ b/MdsSupportingClasses/MdsCheckoutFields.php
@@ -90,7 +90,7 @@ class MdsCheckoutFields
                 $suburbs = ['' => 'First select town/city'] + $suburbs;
             }
 
-            return [
+            $fields = [
                 $prefix.'country' => [
                     'priority' => 1,
                     'type' => 'country',
@@ -213,6 +213,11 @@ class MdsCheckoutFields
                     'autocomplete' => 'postal-code',
                 ],
             ];
+
+	        // Ensure we don't steamroll fields added by other plugins
+            $customFields = array_diff_key($defaultFields, $fields);
+
+            return array_merge($customFields, $fields);
         } catch (InvalidResourceDataException $e) {
             return $prefix ? $this->defaultFields[$prefix] : $this->defaultFields;
         }

--- a/collivery.php
+++ b/collivery.php
@@ -3,7 +3,7 @@
 use MdsSupportingClasses\MdsColliveryService;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '4.1.8');
+define('MDS_VERSION', '4.1.9');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -12,11 +12,11 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 4.1.8
+ * Version: 4.1.9
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 4.0
- * WC tested up to: 5.1.0
+ * WC tested up to: 5.3.0
  */
 if( is_plugin_active('woocommerce/woocommerce.php')) {
     register_activation_hook(__FILE__, 'activate_mds');


### PR DESCRIPTION
* dfd881f [change] Bump version numbers
* 828425e [change] Use a simpler syntax for some operations in `MdsCheckoutFields::getCheckoutFields()` 
  - The minimum supported version for this plugin is 7.0.0
* 37197fd [bugfix] Prevent our plugin from overriding any custom address fields added
  - Eg by "Custom Checkout Fields" plugins