### PR TITLE
user `current_time(...)` to get local site time

### DIFF
--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -764,11 +764,12 @@ class MdsColliveryService
             $colliveryOptions['collection_time'] = $overrides['collection_time'];
         } else {
             $leadTime = $this->settings->getValue('lead_time') ?? self::TWENTY_FOUR_HOURS;
-            $collectionTime = date('Y-m-d H:i:s', strtotime(date('Y-m-d H:i:s')." + {$leadTime} hours + 5 minutes"));
+            $collectionTime = date('Y-m-d H:i:s', strtotime(current_time('Y-m-d H:i:s')." + {$leadTime} hours + 5 minutes"));
             // Ensure it's a week day
             while(date('N', strtotime($collectionTime)) >= 6) {
                 $collectionTime = date('Y-m-d H:i:s', strtotime($collectionTime.' + 1 days'));
             }
+
             $colliveryOptions['collection_time'] = $collectionTime;
         }
 


### PR DESCRIPTION
The incorrect ime was being used when calculating the collection time, the fix now uses the site time