### PR TITLE
Bugfix/package data/compatibility

### DIFF
--- a/MdsSupportingClasses/EnvironmentInformationBag.php
+++ b/MdsSupportingClasses/EnvironmentInformationBag.php
@@ -40,11 +40,6 @@ class EnvironmentInformationBag
     public $phpVersion;
 
     /**
-     * @var string
-     */
-    public $soapInstalled;
-
-    /**
      * @var array
      */
     protected $settings = [];
@@ -69,7 +64,6 @@ class EnvironmentInformationBag
         $this->appName = 'WooCommerce Plugin - '.preg_replace('/^(http|https):\/\//i', '', $this->appUrl);
         $this->phpVersion = phpversion();
         $this->appVersion = MDS_VERSION;
-        $this->soapInstalled = (extension_loaded('soap')) ? 'yes' : 'no';
     }
 
     /**
@@ -97,7 +91,6 @@ class EnvironmentInformationBag
             'phpVersion' => $this->phpVersion,
             'appVersion' => $this->appVersion,
             'appUrl' => $this->appUrl,
-            'soapInstalled' => $this->soapInstalled,
             'settings' => $this->settings,
         ];
     }

--- a/MdsSupportingClasses/EnvironmentInformationBag.php
+++ b/MdsSupportingClasses/EnvironmentInformationBag.php
@@ -59,9 +59,9 @@ class EnvironmentInformationBag
 
         $this->wordpressVersion = $wp_version;
         $this->woocommerceVersion = $this->getWoocommerceVersionNumber();
-        $this->appHost = 'Wordpress: '.$wp_version.' - WooCommerce: '.$this->woocommerceVersion;
+        $this->appHost = 'WP: '.$wp_version.' - WC: '.$this->woocommerceVersion;
         $this->appUrl = get_site_url();
-        $this->appName = 'WooCommerce Plugin - '.preg_replace('/^(http|https):\/\//i', '', $this->appUrl);
+        $this->appName = 'WC Plugin - '.preg_replace('/^(http|https):\/\//i', '', $this->appUrl);
         $this->phpVersion = phpversion();
         $this->appVersion = MDS_VERSION;
     }

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -1027,31 +1027,24 @@ class MdsColliveryService
     /**
      * Gets default address of the MDS Account.
      *
-     * @return array|bool
+     * @return array
      */
     public function returnDefaultAddress()
     {
-        try {
-            $default_address_id = $this->collivery->getDefaultAddressId();
-            if (!$default_address = $this->collivery->getAddress($default_address_id)) {
-                return false;
-            }
-
-            $data = [
-                'address' => $default_address,
-                'default_address_id' => $default_address_id,
-            ];
-
-            if (!isset($default_address['contacts'])) {
-                $data['contacts'] = $this->collivery->getContacts($default_address_id);
-            } else {
-                $data['contacts'] = $default_address['contacts'];
-            }
-
-            return $data;
-        } catch (CurlConnectionException $e) {
+        $default_address_id = $this->collivery->getDefaultAddressId();
+        /** @var array $default_address */
+        $default_address = $this->collivery->getAddress($default_address_id);
+        if (! $default_address ) {
             return [];
         }
+
+	    $contacts  = $default_address['contacts'] ?? $this->collivery->getContacts( $default_address_id );
+
+	    return [
+            'address' => $default_address,
+            'default_address_id' => $default_address_id,
+            'contacts' => $contacts,
+        ];
     }
 
     /**

--- a/WC_Mds_Shipping_Method.php
+++ b/WC_Mds_Shipping_Method.php
@@ -207,16 +207,16 @@ class WC_Mds_Shipping_Method extends WC_Shipping_Method
                                     $riskCover = true;
                                 }
 
-                                $data = [
-                                    'delivery_town' => $package['destination']['to_town_id'],
-                                    'collection_town' => $package['destination']['from_town_id'],
-                                    'delivery_location_type' => $package['destination']['to_location_type'],
-                                    'collection_location_type' => $package['destination']['from_location_type'],
-                                    'risk_cover' => $riskCover,
-                                    'parcels' => $package['cart']['products'],
-                                    'exclude_weekend' => true,
-                                    'services' => [$service['id']],
-                                ];
+                $data = [
+                    'delivery_town'            => $package['destination']['to_town_id'],
+                    'collection_town'          => $package['destination']['from_town_id'],
+                    'delivery_location_type'   => $package['destination']['to_location_type'],
+                    'collection_location_type' => $package['destination']['from_location_type'],
+                    'risk_cover'               => $riskCover,
+                    'parcels'                  => $package['contents'],
+                    'exclude_weekend'          => true,
+                    'services'                 => [ $service['id'] ],
+                ];
 
                                 // Add the requested time to ONX before 10
                                 if ($service['id'] === Collivery::ONX_10) {

--- a/collivery.php
+++ b/collivery.php
@@ -32,7 +32,7 @@ if( is_plugin_active('woocommerce/woocommerce.php')) {
         {
             if (!version_compare(phpversion(), '7.0.0', '>=')) {
                 deactivate_plugins(basename(__FILE__));
-                wp_die('Sorry, but you cannot run this plugin, it requires PHP version 5.4 or higher');
+                wp_die('Sorry, but you cannot run this plugin, it requires PHP version 7.0.0 or higher');
             }
 
             global $wpdb;

--- a/collivery.php
+++ b/collivery.php
@@ -4,7 +4,7 @@ use MdsSupportingClasses\MdsColliveryService;
 use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
-define('MDS_VERSION', '4.1.15');
+define('MDS_VERSION', '4.2.0');
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
 include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -13,7 +13,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin Name: MDS Collivery
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
- * Version: 4.1.15
+ * Version: 4.2.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * WC requires at least: 4.0

--- a/collivery.php
+++ b/collivery.php
@@ -30,11 +30,6 @@ if( is_plugin_active('woocommerce/woocommerce.php')) {
          */
         function activate_mds()
         {
-            if (!class_exists('SoapClient')) {
-                deactivate_plugins(basename(__FILE__));
-                wp_die('Sorry, but you cannot run this plugin, it requires the <a href="http://php.net/manual/en/class.soapclient.php">SOAP</a> support on your server/hosting to function.');
-            }
-
             if (!version_compare(phpversion(), '7.0.0', '>=')) {
                 deactivate_plugins(basename(__FILE__));
                 wp_die('Sorry, but you cannot run this plugin, it requires PHP version 5.4 or higher');

--- a/collivery.php
+++ b/collivery.php
@@ -1,6 +1,7 @@
 <?php
 
 use MdsSupportingClasses\MdsColliveryService;
+use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
 define('MDS_VERSION', '4.1.15');
@@ -142,13 +143,11 @@ if( is_plugin_active('woocommerce/woocommerce.php')) {
          *
          * @param $packages
          *
-         * @return mixed
+         * @return array
          */
         function mds_collivery_cart_shipping_packages($packages)
         {
-            $shippingPackage = new \MdsSupportingClasses\ShippingPackageData();
-
-            return $shippingPackage->build($packages, $_POST);
+            return (new ShippingPackageData())->build($packages, $_POST);
         }
 
         add_filter('woocommerce_cart_shipping_packages', 'mds_collivery_cart_shipping_packages');

--- a/collivery.php
+++ b/collivery.php
@@ -16,6 +16,9 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Version: 4.2.0
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
+ * Requires PHP: 7.0.0
+ * Requires at least: 5.0
+ * Tested up to: 5.8
  * WC requires at least: 4.0
  * WC tested up to: 5.5.2
  */


### PR DESCRIPTION
* 84d3754 [bugfix] Use the default structure for the WooCommerce `packages`
  - Any other plugins that deal with the `packages` or the `WC_Cart` instance will expect a certain data structure
  - Do not remove items from the `packages`
  - Do not rewrite the array keys
  - Do not reference new data structures for the `products`, use the existing `package['contents']`
    * We can reference the nested `WC_Product`s in that array
  - Refactor the logic to reduce nested `if ... else` statements
  - Move logic into `ShippingPackageData`
    * That's the only place it's used, it has no business being inside the `MdsColliveryService` class
  - Make use of the null coalescing operator, the minimum version we require is PHP 7.0
* 7b1da28 [change] Refactor and simplify `WC_Mds_Shipping_Method::calculate_shipping()`
  - Reduce nested `if ... else` statements by `return`ing early
  - Use null coalescence to reduce `isset() && ` logic
  - Apply the wordpress coding standard 🤢
  - Remove the `@throws` annotation. It's not accurate
* 36c70c7 [bugfix] We don't require SOAP extension since switching to the v3 REST API
* b4ddee9 [change] Shorten the metadata headers that get sent
  - They are often truncated when stored
* 1369278 [change] Clean up and simplify `MdsColliveryService::returnDefaultAddress()`
  - Remove the `try ... catch`, that exception is never thrown
  - Use null coalescence instead of an `isset()`
  - Ensure we always return only one data type
* 73e791c [change] Update the text to correctly reflect the PHP version we are testing for
* c10faca [change] Simplify and correctly annotate `mds_collivery_cart_shipping_packages()`
  - It's a hook for `woocommerce_cart_shipping_packages`
* 1762f14 [change] Bump version number
* 39eddbd [change] Add Wordpress-parseable compatibility headers
  - See https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/