### PR TITLE
Add priority to `woocommerce_checkout_fields` hook

### DIFF
--- a/collivery.php
+++ b/collivery.php
@@ -5,7 +5,7 @@ use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
 
-define('MDS_VERSION', '4.2.7');
+define('MDS_VERSION', '4.2.8');
 
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
@@ -16,7 +16,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
 
- * Version: 4.2.7
+ * Version: 4.2.8
 
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html

--- a/mds_checkout_fields.php
+++ b/mds_checkout_fields.php
@@ -39,7 +39,7 @@ if ($mds->isEnabled()) {
             return $address_fields;
         }
 
-        add_filter('woocommerce_checkout_fields', 'mds_custom_override_checkout_fields');
+        add_filter('woocommerce_checkout_fields', 'mds_custom_override_checkout_fields', 10);
     }
 
     if (!function_exists('mds_custom_checkout_field_update_order_meta')) {


### PR DESCRIPTION
If no priority value is set than it will be considered as the maximum value.
Adding a priority allows better compatibility with other plugins that may also add a `woocommerce_checkout_fields` hook.

Thank you very much for [@Getshacked](https://github.com/Getshacked) for the commits.