### PR TITLE
Cache warnings

### DIFF
--- a/MdsSupportingClasses/MdsCache.php
+++ b/MdsSupportingClasses/MdsCache.php
@@ -116,7 +116,7 @@ class MdsCache
     public function put($name, $value, $time = 1440)
     {
         $cache = ['value' => $value, 'valid' => time() + ($time * 60)];
-        if (file_put_contents($this->cache_dir.$name, json_encode($cache))) {
+        if ($name && file_put_contents($this->cache_dir.$name, json_encode($cache))) {
             $this->cache[$name] = $cache;
 
             return true;

--- a/collivery.php
+++ b/collivery.php
@@ -5,7 +5,7 @@ use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
 
-define('MDS_VERSION', '4.3.5');
+define('MDS_VERSION', '4.3.6');
 
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
@@ -16,15 +16,15 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
 
- * Version: 4.3.5
+ * Version: 4.3.6
 
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html
  * Requires PHP: 7.0.0
  * Requires at least: 5.0
- * Tested up to: 5.8
+ * Tested up to: 6.0.1
  * WC requires at least: 4.0
- * WC tested up to: 5.5.2
+ * WC tested up to: 6.7.0
  */
 if( is_plugin_active('woocommerce/woocommerce.php')) {
     register_activation_hook(__FILE__, 'activate_mds');


### PR DESCRIPTION
Cache files were not being checked correctly before appending to them. this resulted in warnings being displayed causing checkout to stall