### PR TITLE
Create waybills without checkout

### DIFF
--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -13,8 +13,13 @@ class Collivery
     const FRT = 3;
     const ECO = 5;
     const ONX_10 = 6;
+	public static $serviceTexts = [
+		self::ONX => 'Over Night',
+		self::ECO  => 'Road Freight Express',
+		self::FRT  => 'Road Freight'
+	];
 
-    protected $token;
+	protected $token;
     protected $client;
     protected $config;
     protected $errors = [];

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -783,7 +783,7 @@ class Collivery
         if (!isset($data['location_type'])) {
             $this->setError('missing_data', 'location_type not set.');
         } elseif (!isset($location_types[$data['location_type']])) {
-            $this->setError('invalid_data', 'Invalid location_type.');
+            $data['location_type'] = 1;
         }
 
         if (!isset($data['town_id'])) {

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -781,7 +781,7 @@ class Collivery
         $suburbs = $this->make_key_value_array($this->getSuburbs($data['town_id']), 'id', 'name');
 
         if (!isset($data['location_type'])) {
-            $this->setError('missing_data', 'location_type not set.');
+            $data['location_type'] = 1;
         } elseif (!isset($location_types[$data['location_type']])) {
             $data['location_type'] = 1;
         }

--- a/MdsSupportingClasses/Collivery.php
+++ b/MdsSupportingClasses/Collivery.php
@@ -13,13 +13,13 @@ class Collivery
     const FRT = 3;
     const ECO = 5;
     const ONX_10 = 6;
-	public static $serviceTexts = [
-		self::ONX => 'Over Night',
-		self::ECO  => 'Road Freight Express',
-		self::FRT  => 'Road Freight'
-	];
+    public static $serviceTexts = [
+        self::ONX => 'Over Night',
+        self::ECO  => 'Road Freight Express',
+        self::FRT  => 'Road Freight'
+    ];
 
-	protected $token;
+    protected $token;
     protected $client;
     protected $config;
     protected $errors = [];

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -735,12 +735,12 @@ class MdsColliveryService
 		$canProcess = count(array_filter($mustProcessStatuses, fn($value) =>
 			str_contains($value, $order->get_status())));
 
-		if(!$canProcess){
+		if(!$canProcess && $processing){
 			return;
 		}
 
         try {
-            $this->updateStatusOrAddNote($order, 'MDS auto processing has begun.', false, 'processing');
+            $this->updateStatusOrAddNote($order, 'MDS auto processing has begun.', $processing, 'processing');
             $this->orderToCollivery($order, compact('processing'));
         } catch (OrderAlreadyProcessedException $e) {
             $this->updateStatusOrAddNote($order, $e->getMessage(), $processing, 'processing');

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -820,7 +820,7 @@ class MdsColliveryService
         }
 
         if (empty($array['location_type']) || !isset($location_types[$location_type_id])) {
-            throw new InvalidAddressDataException('Invalid location type', 'MdsColliveryService::addColliveryAddress()', $this->loggerSettingsArray(), [$array, $location_types, $location_type_id]);
+            $location_type_id = 1;
         }
 
         if (empty($array['town']) || !isset($towns[$town_id])) {

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -730,9 +730,9 @@ class MdsColliveryService
 		$defaultHooks = [
 			'processing'
 		];
-		$mustProcessHooks = $this->settings->getValue('automatic_mds_processing_statuses', $defaultHooks);
+		$mustProcessStatuses = $this->settings->getValue('automatic_mds_processing_statuses', $defaultHooks);
 
-		$canProcess = count(array_filter($mustProcessHooks, fn($value) =>
+		$canProcess = count(array_filter($mustProcessStatuses, fn($value) =>
 			str_contains($value, $order->get_status())));
 
 		if(!$canProcess){

--- a/MdsSupportingClasses/MdsColliveryService.php
+++ b/MdsSupportingClasses/MdsColliveryService.php
@@ -732,8 +732,11 @@ class MdsColliveryService
 		];
 		$mustProcessStatuses = $this->settings->getValue('automatic_mds_processing_statuses', $defaultHooks);
 
-		$canProcess = count(array_filter($mustProcessStatuses, fn($value) =>
-			str_contains($value, $order->get_status())));
+        $canProcess = count(
+            array_filter($mustProcessStatuses, function($value) use ($order) {
+                return  strpos($value, $order->get_status()) !== false;
+            })
+        );
 
 		if(!$canProcess && $processing){
 			return;

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -9,6 +9,16 @@ class MdsFields
 {
     public static function getFields()
     {
+		$services = Collivery::$serviceTexts;
+
+		$orderStatuses = wc_get_order_statuses();
+
+		$wcStatuses = array();
+		foreach ($orderStatuses as $key => $label) {
+			$modifiedKey = str_replace('wc-', '', $key);
+			$wcStatuses[$modifiedKey] = $label;
+		}
+
         return [
             'downloadLogs' => [
                 'title' => __('Clear Cache/Download Error Logs?'),
@@ -169,6 +179,15 @@ class MdsFields
                 ),
                 'default' => 'no',
             ],
+			'automatic_mds_processing_statuses' => [
+				'title'       => __('Auto Processing Status'),
+				'type'        => 'multiselect',
+				'options'     => $wcStatuses,
+				'default'     => [
+					'processing'
+				],
+				'description' => __('Select the statuses that will trigger Automatic MDS Processing. (Hold CTRL to select multiple'),
+			],
             'auto_accept' => [
                 'title' => __('Auto accept'),
                 'type' => 'checkbox',
@@ -177,13 +196,21 @@ class MdsFields
                 ),
                 'default' => 'yes',
             ],
-            'enable_town_suburb_search'=> [
-                'title' => __('Enable Town Suburb Search'),
-                'type' => 'checkbox',
-                'default' => 'no',
-                'description' => __('Allow searching for suburb on checkout.'),
+			'enable_town_suburb_search'=> [
+				'title' => __('Enable Town Suburb Search'),
+				'type' => 'checkbox',
+				'default' => 'no',
+				'description' => __('Allow searching for suburb on checkout.'),
 
-            ]
+			],
+			'fall_back_service'=> [
+				'title' => __('Fall Back Service'),
+				'type' => 'select',
+				'options' => $services,
+				'default' => 2,
+				'description' => __('Default Service when no service selected on checkout. Allows you to have any shipping method but still create MDS Collivery Waybills'),
+
+			]
         ];
     }
 

--- a/MdsSupportingClasses/MdsFields.php
+++ b/MdsSupportingClasses/MdsFields.php
@@ -180,13 +180,13 @@ class MdsFields
                 'default' => 'no',
             ],
 			'automatic_mds_processing_statuses' => [
-				'title'       => __('Auto Processing Status'),
+				'title'       => __('Auto Processing Statuses'),
 				'type'        => 'multiselect',
 				'options'     => $wcStatuses,
 				'default'     => [
 					'processing'
 				],
-				'description' => __('Select the statuses that will trigger Automatic MDS Processing. (Hold CTRL to select multiple'),
+				'description' => __('Select the statuses that will trigger Automatic MDS Processing. (Hold CTRL to select multiple)'),
 			],
             'auto_accept' => [
                 'title' => __('Auto accept'),

--- a/collivery.php
+++ b/collivery.php
@@ -302,7 +302,7 @@ if( is_plugin_active('woocommerce/woocommerce.php')) {
         }
 
         if ($mds->isEnabled() && $settings->getValue('toggle_automatic_mds_processing') == 'yes') {
-            add_action('woocommerce_order_status_processing', 'automated_add_collivery_status_processing');
+            add_action('woocommerce_order_status_changed', 'automated_add_collivery_status_processing');
         }
     }
 

--- a/collivery.php
+++ b/collivery.php
@@ -5,7 +5,7 @@ use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
 
-define('MDS_VERSION', '4.4.2');
+define('MDS_VERSION', '4.4.3');
 
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
@@ -16,7 +16,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
 
- * Version: 4.4.2
+ * Version: 4.4.3
 
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html

--- a/collivery.php
+++ b/collivery.php
@@ -5,7 +5,7 @@ use MdsSupportingClasses\ShippingPackageData;
 
 define('_MDS_DIR_', __DIR__);
 
-define('MDS_VERSION', '4.4.3');
+define('MDS_VERSION', '4.4.4');
 
 include 'autoload.php';
 require_once ABSPATH.'wp-includes/functions.php';
@@ -16,7 +16,7 @@ include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
  * Plugin URI: https://collivery.net/integration/woocommerce
  * Description: Plugin to add support for MDS Collivery in WooCommerce.
 
- * Version: 4.4.3
+ * Version: 4.4.4
 
  * Author: MDS Technologies
  * License: GNU/GPL version 3 or later: http://www.gnu.org/licenses/gpl.html


### PR DESCRIPTION
- Add new Settings
- Fallback service 
New Settings for fallback service allow the plugin to still be used even if there is not a MDS Shipping method selected.

- Auto Processing status triggers
Users can now select which statuses allow the waybills to be created

