### PR TITLE
convert the strings

### DIFF
--- a/MdsSupportingClasses/ShippingPackageData.php
+++ b/MdsSupportingClasses/ShippingPackageData.php
@@ -328,7 +328,7 @@ class ShippingPackageData
 			$package['contents'][$hash] = $item;
 
 			// Work out Volumetric Weight based on MDS calculations
-			$volWeight = ($length * $width * $height) / 4000;
+            $volWeight = ((int)$length * (int)$width * (int)$height) / 4000;
 
 			$package['max_weight'] += $volWeight > $weight ?
 				$volWeight * $quantity :


### PR DESCRIPTION
 - PHP 8 doesn’t allow string variables to calculate integer variables, so the website crashes with a 500 Server Error when your plugin does shipping calculations for these quote only/non-shipping products.